### PR TITLE
Added optional `graphControls` boolean setting. addresses #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install --save react-digraph
 
 The default export is a component called 'GraphView'; it provides a multitude of hooks for various graph editing operations and a set of controls for zooming. Typically, it should be wrapped in a higher order component that supplies various callbacks (onCreateNode, onCreateEdge etc...).
 
-All nodes and edges can have a type attribute set - nodes also support a subtype attribute. These can be passed to GraphView via the nodeTypes, nodeSubtypes, and edgeTypes props. GraphView will look up the corresponding SVG elements for the node's type/subtype and the edge's type and draw it accordingly. 
+All nodes and edges can have a type attribute set - nodes also support a subtype attribute. These can be passed to GraphView via the nodeTypes, nodeSubtypes, and edgeTypes props. GraphView will look up the corresponding SVG elements for the node's type/subtype and the edge's type and draw it accordingly.
 
 It is often convenient to combine these types into a configuration object that can be referred to elsewhere in the application and used to associate events fired from nodes/edges in the graphView with other actions in the application. Here is an abbreviated example:
 
@@ -35,8 +35,8 @@ const GraphConfig =  {
         </symbol>
       )
     }
-  }, 
-  NodeSubtypes: {}, 
+  },
+  NodeSubtypes: {},
   EdgeTypes: {
     emptyEdge: {
       shapeId: "#emptyEdge",
@@ -49,7 +49,7 @@ const GraphConfig =  {
   }
 }
 
-const EMPTY_TYPE = "empty"  // Text on empty nodes is positioned differently 
+const EMPTY_TYPE = "empty"  // Text on empty nodes is positioned differently
 const NODE_KEY = "id"       // Allows D3 to correctly update DOM
 
 class Graph extends Component {
@@ -76,7 +76,7 @@ class Graph extends Component {
 
     return (
       <div id='graph' style={styles.graph}>
-      
+
         <GraphView  ref='GraphView'
                     nodeKey={NODE_KEY}
                     emptyType={EMPTY_TYPE}
@@ -153,11 +153,11 @@ A typical graph that would be stored in the Graph component's state looks someth
 ```
 
 
-For a detailed example, check out src/examples/graph.js. 
+For a detailed example, check out src/examples/graph.js.
 To run the example:
 ```
 npm install
-npm run example 
+npm run example
 ```
 go to localhost:8000.
 
@@ -215,6 +215,7 @@ All props are detailed below.
 | edgeArrowSize       | number  | false     | Edge arrow size.                          |
 | zoomDelay           | number  | false     | Delay before zoom occurs.                 |
 | zoomDur             | number  | false     | Duration of zoom transition.              |
+| graphControls       | boolean | true      | Whether to show zoom controls.            |
 
 ## Notes
 

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -836,13 +836,15 @@ class GraphView extends Component {
             <g id='entities' ref={(el) => this.entities = el}></g>
           </g>
         </svg>
+        {this.props.graphControls && (
         <GraphControls  primary={this.props.primary}
-                        minZoom={this.props.minZoom} 
-                        maxZoom={this.props.maxZoom} 
-                        zoomLevel={this.state.viewTransform.k} 
-                        zoomToFit={this.handleZoomToFit} 
+                        minZoom={this.props.minZoom}
+                        maxZoom={this.props.maxZoom}
+                        zoomLevel={this.state.viewTransform.k}
+                        zoomToFit={this.handleZoomToFit}
                         modifyZoom={this.modifyZoom}>
         </GraphControls>
+        )}
       </div>
     );
   }
@@ -891,7 +893,8 @@ GraphView.propTypes = {
   edgeHandleSize: PropTypes.number,
   edgeArrowSize: PropTypes.number,
   zoomDelay: PropTypes.number, // ms
-  zoomDur: PropTypes.number // ms
+  zoomDur: PropTypes.number, // ms
+  graphControls: PropTypes.bool,
 };
 
 GraphView.defaultProps = {
@@ -911,6 +914,7 @@ GraphView.defaultProps = {
   edgeArrowSize: 8,
   zoomDelay: 500,
   zoomDur: 750,
+  graphControls: true,
   renderEdge: (graphView, domNode, datum, index, elements )=>{
 
     // For new edges, add necessary child domNodes


### PR DESCRIPTION
Per issue #17 I've done the simplest approach which is a new, optional `graphControls` boolean prop. It defaults to `true` as per current behaviour. If disabled the graph controls do not get rendered.

NOTE: some line ending whitespace trimming added by my editor to `README.md`.