### PR TITLE
fix cause of radium error

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "main": "dist/index.js",
   "peerDependencies": {
     "d3": "^4.1.1",
-    "radium": "^0.18.1",
+    "radium": "^0.19.5",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-icons": "^2.2.1"


### PR DESCRIPTION
fixes #20

also, consider removing duplicate dependencies listed in `devDependencies` and `peerDependencies`.

if a package is listed in `peerDependencies`, it should be required for both development and production builds.

duplicating dependencies cause cause confusion and allows requirements to get out of sync.