### PR TITLE
improve `onEdgeCreate` handler in example

### DIFF
--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -221,8 +221,12 @@ class Graph extends Component {
       target: targetViewNode[NODE_KEY],
       type: type
     }
-    graph.edges.push(viewEdge);
-    this.setState({graph: graph});
+    
+    // Only add the edge when the source node is not the same as the target
+    if (viewEdge.source !== viewEdge.target) {
+      graph.edges.push(viewEdge);
+      this.setState({graph: graph});
+    }
   }
 
   // Called when an edge is reattached to a different target.


### PR DESCRIPTION
failing to connect an edge from one node to another causes odd behavior:
![source-connected-to-itself](https://user-images.githubusercontent.com/4097374/33234776-308af3e6-d1e1-11e7-889c-a06ff35caa31.png)

this can be resolved if edges are only added when they connect two unique nodes.

