### PR TITLE
update graph control input style

### DIFF
--- a/src/components/graph-controls.js
+++ b/src/components/graph-controls.js
@@ -57,7 +57,8 @@ function makeStyles(primary){
       position: 'relative',
       top: '6px',
       marginLeft: 5,
-      marginRight: 5
+      marginRight: 5,
+      cursor: 'pointer'
     },
     button: {
       backgroundColor: 'white',

--- a/src/components/graph-controls.js
+++ b/src/components/graph-controls.js
@@ -49,11 +49,13 @@ function makeStyles(primary){
       color: primary,
       border: `solid 1px lightgray`,
       padding: '6.5px',
-      marginRight: '15px'
+      marginRight: '15px',
+      display: 'inline',
+      borderRadius: '2px'
     },
     slider: {
       position: 'relative',
-      top: 3,
+      top: '6px',
       marginLeft: 5,
       marginRight: 5
     },
@@ -62,10 +64,10 @@ function makeStyles(primary){
       color: primary,
       border: `solid 1px lightgray`,
       outline: 'none',
-      position: 'absolute',
       width: 31,
       height: 31,
-      top: -3
+      borderRadius: '2px',
+      cursor: 'pointer'
     }
   }
 }
@@ -112,7 +114,7 @@ class GraphControls extends Component {
 
     return (
       <div style={styles.controls} id="GraphControls">
-        <span style={styles.sliderWrapper}>
+        <div style={styles.sliderWrapper}>
           -
           <input 
             id="typeinp" 
@@ -124,7 +126,7 @@ class GraphControls extends Component {
             onChange={this.zoom.bind(this)}
             step="1"/>
           +
-        </span>
+        </div>
         <button style={styles.button} onMouseDown={this.props.zoomToFit}>
           <FaExpand/>
         </button>


### PR DESCRIPTION
the graph control is rendering a little funky in chrome.  here's what it looks like:
![graph-control](https://user-images.githubusercontent.com/4097374/33244038-2c5aac0c-d2a5-11e7-8637-6b1bfa2272ff.png)

the horizontal alignment is a little off, and the slider input is pushed toward the top of it's container.

here is what it looks like in chrome with the proposed changes:
![graph-control](https://user-images.githubusercontent.com/4097374/33243994-795a6c5a-d2a4-11e7-8722-605c151cfc51.png)

and here is what it looks like in firefox with the proposed changes:
![graph-control](https://user-images.githubusercontent.com/4097374/33243999-9b3a35a8-d2a4-11e7-9d77-c33cda1f7f17.png)

I didn't test in any other browsers.