### PR TITLE
fixed rendering bug

### DIFF
--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -313,11 +313,13 @@ class GraphView extends Component {
         if( swapEdge ){
           if(self.props.canDeleteEdge(swapEdge) && self.canSwap(sourceNode,hoveredNode,swapEdge)){
             self.props.onSwapEdge(sourceNode, hoveredNode, swapEdge)
+            self.renderView()
           } else {
             swapErrBack()
           }
         } else {
           self.props.onCreateEdge(sourceNode, hoveredNode)
+          self.renderView()
         }
       } else {
         if (swapErrBack){
@@ -427,6 +429,7 @@ class GraphView extends Component {
       if (!this.state.readOnly && d3.event.shiftKey) {
         var xycoords = d3.mouse(event.target);
         this.props.onCreateNode(xycoords[0],xycoords[1]);
+        this.renderView()
       }
 
     }
@@ -918,7 +921,6 @@ GraphView.defaultProps = {
   zoomDur: 750,
   graphControls: true,
   renderEdge: (graphView, domNode, datum, index, elements )=>{
-
     // For new edges, add necessary child domNodes
     if (!domNode.hasChildNodes()){
       d3.select(domNode).append("path");


### PR DESCRIPTION
fixes #13 

call `renderView()` immediately after creating a node, creating an edge and swapping an edge.