### PR TITLE
Remove document listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ jshint.xml
 jshint-proper.xml
 
 core
+package-lock.json
 npm-debug.log
 
 dist/

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-digraph",
   "description": "directed graph react component",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "keywords": [
     "uber-library",
     "babel",

--- a/src/components/graph-controls.js
+++ b/src/components/graph-controls.js
@@ -42,15 +42,17 @@ function makeStyles(primary){
       position: 'absolute',
       bottom: '30px',
       left: '15px',
-      zIndex: 100
+      zIndex: 100,
+      display: 'grid',
+      gridTemplateColumns: 'auto auto',
+      gridGap: '15px',
+      alignItems: 'center'
     },
     sliderWrapper: {
       backgroundColor: 'white',
       color: primary,
       border: `solid 1px lightgray`,
       padding: '6.5px',
-      marginRight: '15px',
-      display: 'inline',
       borderRadius: '2px'
     },
     slider: {
@@ -104,7 +106,7 @@ class GraphControls extends Component {
     let sliderVal = e.target.value;
     let zoomLevelNext = this.sliderToZoom(sliderVal);
     let delta = zoomLevelNext-this.props.zoomLevel;
-    
+
     if( zoomLevelNext <= this.props.maxZoom && zoomLevelNext >= this.props.minZoom){
       this.props.modifyZoom(delta)
     }
@@ -114,16 +116,15 @@ class GraphControls extends Component {
     const styles = this.state.styles;
 
     return (
-      <div style={styles.controls} id="GraphControls">
+      <div style={styles.controls} className="graphControls">
         <div style={styles.sliderWrapper}>
           -
-          <input 
-            id="typeinp" 
+          <input
             type="range"
-            style={styles.slider} 
-            min={this.zoomToSlider(this.props.minZoom)} 
-            max={this.zoomToSlider(this.props.maxZoom)} 
-            value={this.zoomToSlider(this.props.zoomLevel)} 
+            style={styles.slider}
+            min={this.zoomToSlider(this.props.minZoom)}
+            max={this.zoomToSlider(this.props.maxZoom)}
+            value={this.zoomToSlider(this.props.zoomLevel)}
             onChange={this.zoom.bind(this)}
             step="1"/>
           +

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -41,13 +41,13 @@ const NODE_KEY = "id" // Key used to identify nodes
 // However, GraphView renders text differently for empty types
 // so this has to be passed in if that behavior is desired.
 const EMPTY_TYPE = "empty"; // Empty node type
-const SPECIAL_TYPE = "special"; 
+const SPECIAL_TYPE = "special";
 const SPECIAL_CHILD_SUBTYPE = "specialChild";
 const EMPTY_EDGE_TYPE = "emptyEdge";
 const SPECIAL_EDGE_TYPE = "specialEdge";
 
 // NOTE: Edges must have 'source' & 'target' attributes
-// In a more realistic use case, the graph would probably originate 
+// In a more realistic use case, the graph would probably originate
 // elsewhere in the App or be generated from some other state upstream of this component.
 const sample = {
   "nodes": [
@@ -133,7 +133,7 @@ class Graph extends Component {
    * Handlers/Interaction
    */
 
-  // Called by 'drag' handler, etc.. 
+  // Called by 'drag' handler, etc..
   // to sync updates from D3 with the graph
   onUpdateNode = viewNode => {
     const graph = this.state.graph;
@@ -162,7 +162,7 @@ class Graph extends Component {
   onCreateNode = (x,y) => {
     const graph = this.state.graph;
 
-    // This is just an example - any sort of logic 
+    // This is just an example - any sort of logic
     // could be used here to determine node type
     // There is also support for subtypes. (see 'sample' above)
     // The subtype geometry will underlay the 'type' geometry for a node
@@ -188,7 +188,7 @@ class Graph extends Component {
 
     // Delete any connected edges
     const newEdges = graph.edges.filter((edge, i)=>{
-      return  edge.source != viewNode[NODE_KEY] && 
+      return  edge.source != viewNode[NODE_KEY] &&
               edge.target != viewNode[NODE_KEY]
     })
 
@@ -201,7 +201,7 @@ class Graph extends Component {
   onCreateEdge = (sourceViewNode, targetViewNode) => {
     const graph = this.state.graph;
 
-    // This is just an example - any sort of logic 
+    // This is just an example - any sort of logic
     // could be used here to determine edge type
     const type = sourceViewNode.type === SPECIAL_TYPE ? SPECIAL_EDGE_TYPE : EMPTY_EDGE_TYPE;
 
@@ -210,7 +210,7 @@ class Graph extends Component {
       target: targetViewNode[NODE_KEY],
       type: type
     }
-    
+
     // Only add the edge when the source node is not the same as the target
     if (viewEdge.source !== viewEdge.target) {
       graph.edges.push(viewEdge);
@@ -254,25 +254,27 @@ class Graph extends Component {
 
     return (
       <div id='graph' style={styles.graph}>
-      
-        <GraphView  ref={(el) => this.GraphView = el}
-                    nodeKey={NODE_KEY}
-                    emptyType={EMPTY_TYPE}
-                    nodes={nodes}
-                    edges={edges}
-                    selected={selected}
-                    nodeTypes={NodeTypes}
-                    nodeSubtypes={NodeSubtypes}
-                    edgeTypes={EdgeTypes}
-                    getViewNode={this.getViewNode}
-                    onSelectNode={this.onSelectNode}
-                    onCreateNode={this.onCreateNode}
-                    onUpdateNode={this.onUpdateNode}
-                    onDeleteNode={this.onDeleteNode}
-                    onSelectEdge={this.onSelectEdge}
-                    onCreateEdge={this.onCreateEdge}
-                    onSwapEdge={this.onSwapEdge}
-                    onDeleteEdge={this.onDeleteEdge}/>
+
+        <GraphView
+          ref={(el) => this.GraphView = el}
+          nodeKey={NODE_KEY}
+          emptyType={EMPTY_TYPE}
+          nodes={nodes}
+          edges={edges}
+          selected={selected}
+          nodeTypes={NodeTypes}
+          nodeSubtypes={NodeSubtypes}
+          edgeTypes={EdgeTypes}
+          enableFocus={true}
+          getViewNode={this.getViewNode}
+          onSelectNode={this.onSelectNode}
+          onCreateNode={this.onCreateNode}
+          onUpdateNode={this.onUpdateNode}
+          onDeleteNode={this.onDeleteNode}
+          onSelectEdge={this.onSelectEdge}
+          onCreateEdge={this.onCreateEdge}
+          onSwapEdge={this.onSwapEdge}
+          onDeleteEdge={this.onDeleteEdge}/>
       </div>
     );
   }

--- a/src/test/components/graph-view.js
+++ b/src/test/components/graph-view.js
@@ -73,13 +73,13 @@ const config = {
       shapeId: "#special",
       shape: SpecialShape
     }
-  }, 
+  },
   NodeSubtypes: {
     specialChild: {
       shapeId: "#specialChild",
       shape: SpecialChildShape
     }
-  }, 
+  },
   EdgeTypes: {
     emptyEdge: {
       shapeId: "#emptyEdge",
@@ -93,7 +93,7 @@ const config = {
 }
 
 const EMPTY_TYPE = "empty"; // Empty node type
-const SPECIAL_TYPE = "special"; 
+const SPECIAL_TYPE = "special";
 const SPECIAL_CHILD_SUBTYPE = "specialChild";
 const EMPTY_EDGE_TYPE = "emptyEdge";
 const SPECIAL_EDGE_TYPE = "specialEdge";
@@ -174,13 +174,13 @@ const tests = function(){
 
   test('GraphView', t => {
     const wrapper = mount(<GraphView {...mockProps}/>);
-    t.equal(wrapper.find('#viewWrapper').length, 1, 'Renders wrapper');
+    t.equal(wrapper.find('.viewWrapper').length, 1, 'Renders wrapper');
 
-    const view = wrapper.find('#view').render()
+    const view = wrapper.find('.view').render()
     t.equal(view.find('.node').length, 4, 'Renders nodes');
     t.equal(view.find('.edge').length, 2, 'Renders edges');
 
-    const controls = wrapper.find('#GraphControls')
+    const controls = wrapper.find('.graphControls')
     t.equal(controls.length, 1, 'Renders controls');
 
     t.end();


### PR DESCRIPTION
Main issue:
 - Since the digraph listens to the whole document for the delete key, if you are in a text box no associated with the digraph and delete characters, you'll delete objects in the graph

Other things fixed
 - Center aligned graph controls
 - Removed all ids (since you could render two of these controls side by side)