### PR TITLE
Hack-fixed clicking on path of edge should select edge

### DIFF
--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -396,6 +396,8 @@ class GraphView extends Component {
   }
 
   handleSvgClicked(d, i) {
+    if (d3.event.target.tagName == 'path') return false; // If the handle is clicked
+
     if (this.state.selectingNode) {
       this.setState({
         selectingNode: false

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -396,20 +396,8 @@ class GraphView extends Component {
   }
 
   handleSvgClicked(d, i) {
-<<<<<<< HEAD
     if (d3.event.target.tagName == 'path') return false; // If the handle is clicked
 
-=======
-
-    if (d3.event.target.tagName == 'path') return false; // If the handle is clicked
-
-    if (!this.state.focused){
-      this.setState({
-        focused: true
-      })
-    }
-
->>>>>>> 53c44ad5f6405af4881a9f43687e4206609e70fd
     if (this.state.selectingNode) {
       this.setState({
         selectingNode: false


### PR DESCRIPTION
Seems that both handleEdgeMouseDown and handleSvgClicked are fired. I tried to run `d3.event.preventDefault()` in handleEdgeMouseDown but it had no effect. I'd love a cleaner more understandable solution but this is all I got so far.