### PR TITLE
Allow clicking anywhere on the edge (even children)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-digraph",
   "description": "directed graph react component",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "keywords": [
     "uber-library",
     "babel",

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -398,7 +398,7 @@ class GraphView extends Component {
   }
 
   handleSvgClicked(d, i) {
-    if (d3.event.target.tagName == 'path') return false; // If the handle is clicked
+    if (this.isPartOfEdge(d3.event.target)) return false; // If the handle is clicked
 
     if (this.state.selectingNode) {
       this.setState({
@@ -416,6 +416,16 @@ class GraphView extends Component {
 
     }
   }
+
+  isPartOfEdge(element) {
+    while (element != null && element != this.viewWrapper) {
+      if (element.classList.contains("edge")) {
+        return true;
+      }
+      element = element.parentElement;
+    }
+    return false;
+  };
 
   handleNodeMouseDown(d) {
     if (d3.event.defaultPrevented) {
@@ -815,9 +825,6 @@ class GraphView extends Component {
       <div
           className='viewWrapper'
           tabIndex={0}
-          onClick={() => {
-            this.props.onSelectNode(null);
-          }}
           onFocus={() => {
             this.setState({
               focused: true

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -398,7 +398,7 @@ class GraphView extends Component {
   }
 
   handleSvgClicked(d, i) {
-    if (this.isPartOfEdge(d3.event.target)) return false; // If the handle is clicked
+    if (this.isPartOfEdge(d3.event.target)) return; // If any part of the edge is clicked, return
 
     if (this.state.selectingNode) {
       this.setState({


### PR DESCRIPTION
I'm still not sure why I don't have to do the same thing for nodes... If anyone can provide background, that would be amazing!

Anyways, this extends the check of "path" to generally be any child of an edge.