### PR TITLE
Added click handler to node to block propagation race condition.

### DIFF
--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -371,11 +371,11 @@ class GraphView extends Component {
     if (this.props.selected) {
       const selected = this.props.selected;
       if (!selected.source && this.props.canDeleteNode(selected)) {
-          this.props.onDeleteNode(selected);
-          this.props.onSelectNode(null);
+        this.props.onDeleteNode(selected);
+        this.props.onSelectNode(null);
       } else if (selected.source && this.props.canDeleteEdge(selected)) {
-          this.props.onDeleteEdge(selected);
-          this.props.onSelectNode(null);
+        this.props.onDeleteEdge(selected);
+        this.props.onSelectNode(null);
       }
     }
   }
@@ -808,6 +808,13 @@ class GraphView extends Component {
 
     newNodes.on("mousedown", this.handleNodeMouseDown)
       .on("mouseup", this.handleNodeMouseUp)
+      .on("click", (d) => {
+        // Force blocking propagation on node click.
+        // It was found that large graphs would handle clicks on the canvas even
+        // though the mouseDown event blocked propagation.
+        d3.event.stopPropagation();
+        d3.event.preventDefault();
+      })
       .on("mouseenter", this.handleNodeMouseEnter)
       .on("mouseleave", this.handleNodeMouseLeave)
       .call(d3.drag().on("start", this.handleNodeDrag));


### PR DESCRIPTION
In the past the `mouseUp` event happened after a `click` event, or the `mouseDown` event blocked the `click` event from firing (not sure which case is true). The thought is that in order for `click` to fire on the SVG it requires an unblocked `mouseDown` and an upblocked `mouseUp`. On smaller graphs this worked fine, as the click event would happen before the `state.selectingNode` code was set to false, but on larger graphs the `mouseUp` event fired before the `click` event, so the `selectingNode` state was already set to false, and the `handleSvgClick` code attempted to de-select a node in error.

This change adds a click event to nodes which blocks the SVG click altogether.