### PR TITLE
Add extra checks to prevent errors with no apparent consequence

### DIFF
--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -343,7 +343,7 @@ class GraphView extends Component {
       if(!self.props.readOnly){
         var d = d3.select(this).datum();
         // Move the node back to the original z-index
-        if (oldSibling) {
+        if (oldSibling && oldSibling.parentElement) {
           oldSibling.parentElement.insertBefore(this, oldSibling);
         }
         self.props.onUpdateNode(d);
@@ -658,6 +658,11 @@ class GraphView extends Component {
   getEdgeHandleTransformation = (edge) => {
     let src = this.props.getViewNode(edge.source);
     let trg = this.props.getViewNode(edge.target);
+
+    if (!(src && trg)) {
+      console.warn("Unable to get both source and target for ", edge);
+      return "";
+    }
 
     let origin = getMidpoint(src, trg);
     let x = origin.x;


### PR DESCRIPTION
We have had a few intermittent errors using react-diagraph in production namely:
* `Cannot read property 'insertBefore' of null`
* `Client error: 'Cannot read property 'x' of undefined`

Both of these within `graph-view.js` and seem to have no consequence.

I have followed the defensive check pattern used in `getPathDescription` in `getEdgeHandleTransformation`. This avoids the  `Cannot read property 'x' of undefined` error.

I have put an extra defensive check in `dragNode`s inline `ended` function as an assumption in this code doesn't seem to be valid. This prevents the `Cannot read property 'insertBefore' of null` error.