### PR TITLE
Allow react 15 or 16 to be used as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "license": "MIT",
   "main": "dist/index.js",
   "peerDependencies": {
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "d3": "^4.1.1",


### PR DESCRIPTION
In #59, [comment mentioned that the package works with `react` 15 or 16](/uber/react-digraph/pull/59#discussion_r213470579). Updated the `peerDependencies` in `package.json` to reflect those version specifications.

This will prevent any `unmet peer dependency` errors for anyone using `react` `>=15 <16.3.0`.