### PR TITLE
Add example.gif to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 src/
 dist/test/
 dist/examples/
+example.gif


### PR DESCRIPTION
This file doesn't need to be published to npm.

You can see the vast majority of the install size is due to the single 1MB+ `example.gif` file https://packagephobia.now.sh/result?p=react-digraph