### PR TITLE
Use babel in webpack configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
+    "babel-register": "^6.26.0",
     "brace": "^0.11.1",
     "browserify": "^14.4.0",
     "build-changelog": "^2.1.2",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,8 +1,8 @@
-const path = require('path');
-const webpack = require('webpack');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
+import path from 'path';
+import {HotModuleReplacementPlugin, WatchIgnorePlugin}  from 'webpack';
+import CopyWebpackPlugin from 'copy-webpack-plugin';
 
-module.exports = {
+export default {
   mode: 'development',
   context: __dirname + '/src',
   entry: {
@@ -109,8 +109,8 @@ module.exports = {
   },
 
   plugins: [
-    new webpack.WatchIgnorePlugin([/\.d\.ts$/]),
-    new webpack.HotModuleReplacementPlugin(),
+    new WatchIgnorePlugin([/\.d\.ts$/]),
+    new HotModuleReplacementPlugin(),
     new CopyWebpackPlugin([
       {
         from: './examples/**/index.html',

--- a/webpack.prod.babel.js
+++ b/webpack.prod.babel.js
@@ -1,8 +1,8 @@
-const path = require('path');
-const webpack = require('webpack');
-const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+import path from 'path';
+import {DefinePlugin} from 'webpack';
+import UglifyJSPlugin from 'uglifyjs-webpack-plugin';
 
-module.exports = {
+export default {
   mode: 'production',
   devtool: 'source-map',
   context: __dirname + '/src',
@@ -80,7 +80,7 @@ module.exports = {
     new UglifyJSPlugin({
       sourceMap: true
     }),
-    new webpack.DefinePlugin({
+    new DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production')
     })
   ],


### PR DESCRIPTION
Generally not a good idea to mix commonjs and es6 exports/imports. Webpack configs will use `babel` if they have a `.babel.js` extension.

Although, I have no idea why `webpack` is even being used (unless it's for tests only). It's bundling all used `node_modules` (excluding it from `babel-loader` does not prevent them from being bundled, just not run through the loader), there's also `peerDependencies` specified? The right approach to this is to use `@babel/cli`, not `webpack`.