### PR TITLE
Use rimraf & npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-icons": "^2.2.1",
     "react-router-dom": "^4.3.1",
     "regenerator-runtime": "^0.12.0",
+    "rimraf": "^2.6.2",
     "sass-loader": "^7.0.3",
     "sinon": "^4.0.1",
     "source-map-loader": "^0.2.3",
@@ -96,7 +97,7 @@
   "scripts": {
     "build": "webpack",
     "build:prod": "webpack --config webpack.prod.js",
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf ./dist",
     "watch": "webpack --watch",
     "build-css": "node-sass --include-path scss src/styles/main.scss dist/styles/main.css && node-sass --include-path scss src/examples/app.scss dist/examples/app.css",
     "changelog-major": "build-changelog --major",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "brace": "^0.11.1",
     "browserify": "^14.4.0",
     "build-changelog": "^2.1.2",
-    "concurrently": "^3.6.0",
     "copy-webpack-plugin": "^4.5.2",
     "css-loader": "^1.0.0",
     "d3": "^5.5.0",
@@ -75,6 +74,7 @@
     "jsdom": "^11.5.1",
     "live-server": "^1.2.0",
     "node-sass": "^4.9.2",
+    "npm-run-all": "^4.1.3",
     "nws": "^1.1.1",
     "opn-cli": "3.1.0",
     "prettier": "^1.12.0",
@@ -109,7 +109,7 @@
     "jenkins-jshint": "npm run lint -- --o=jshint.xml --f=checkstyle",
     "jenkins-test": "npm run jenkins-jshint && npm run test",
     "live-server": "live-server ./dist --entry-file=./index.html",
-    "live-serve": "concurrent \"npm run watch\" \"npm run live-server\"",
+    "live-serve": "npm-run-all --parallel watch live-server",
     "lint": "eslint src",
     "precommit": "npm run lint -s && npm run test",
     "prefast-test": "npm run prepublish",
@@ -117,7 +117,7 @@
     "serve": "npm run live-serve",
     "test": "jest",
     "view-cover": "npm run cover -- --report=html && opn ./coverage/index.html",
-    "package": "npm run clean && npm run lint && npm run test && npm run build && npm run build:prod"
+    "package": "npm-run-all clean lint test build build:prod"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
`rm -rf` is not compatible with all machines, better to use `rimraf` instead.

Having elongated `npm run foo && npm run bar && ...` scripts can be confusing -- use `npm-run-all` to shorten them.

`concurrently` is unnecessary with the `--parallel` flag for `npm-run-all`.