### PR TITLE
Prevent log files from being committed to version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/
 .idea
 
 .DS_Store
+*.log


### PR DESCRIPTION
This prevents `yarn.log` from getting added to version control