### PR TITLE
Fixed zoom issue with d3 v4 adding style property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-digraph",
   "description": "directed graph react component",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "keywords": [
     "uber-library",
     "babel",
@@ -29,7 +29,7 @@
     "react-dom": "^16.3.0"
   },
   "dependencies": {
-    "d3": "^4.1.1",
+    "d3": "^4.13.0",
     "radium": "^0.24.1",
     "react-icons": "^2.2.1"
   },

--- a/src/components/graph-controls.js
+++ b/src/components/graph-controls.js
@@ -102,15 +102,15 @@ class GraphControls extends Component {
   }
 
   // Modify current zoom of graph-view
-  zoom(e){
+  zoom = (e) => {
     let sliderVal = e.target.value;
     let zoomLevelNext = this.sliderToZoom(sliderVal);
-    let delta = zoomLevelNext-this.props.zoomLevel;
+    let delta = zoomLevelNext - this.props.zoomLevel;
 
-    if( zoomLevelNext <= this.props.maxZoom && zoomLevelNext >= this.props.minZoom){
-      this.props.modifyZoom(delta)
+    if (zoomLevelNext <= this.props.maxZoom && zoomLevelNext >= this.props.minZoom) {
+      this.props.modifyZoom(delta);
     }
-  }
+  };
 
   render() {
     const styles = this.state.styles;
@@ -125,7 +125,7 @@ class GraphControls extends Component {
             min={this.zoomToSlider(this.props.minZoom)}
             max={this.zoomToSlider(this.props.maxZoom)}
             value={this.zoomToSlider(this.props.zoomLevel)}
-            onChange={this.zoom.bind(this)}
+            onChange={this.zoom}
             step="1"/>
           +
         </div>

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -616,9 +616,7 @@ class GraphView extends Component {
 
   // Programmatically resets zoom
   setZoom = (k=1, x=0, y=0, dur=0) => {
-
     var t = d3.zoomIdentity.translate(x, y).scale(k);
-
     d3.select(this.viewWrapper).select('svg')
       .transition()
       .duration(dur)
@@ -904,10 +902,15 @@ class GraphView extends Component {
   renderView = () => {
     var nodes = this.props.nodes;
     var edges = this.props.edges;
-
     // Update the view w/ new zoom/pan
-    const view = d3.select(this.view)
-      .attr("transform", this.state.viewTransform);
+    const view = d3.select(this.view);
+    const viewNode = view.node();
+    if (viewNode) {
+      const { k, x, y } = this.state.viewTransform;
+      view.attr("transform", this.state.viewTransform);
+      // viewNode.setAttribute('transform', `translate(${x},${y}) scale(${k})`);
+      viewNode.style.transform = null;
+    }
 
     const entities = d3.select(this.entities);
 


### PR DESCRIPTION
I'm not sure if this fixes #71 as I can't repro the problem, but this certainly does fix a zoom issue that I noticed with d3 v4. I have a StackOverflow question out for it as well, so hopefully we won't need to use hacks.

https://stackoverflow.com/questions/52430636/d3-js-v4-adds-transform-matrix-style-when-transform-attribute-is-modified-preve