### PR TITLE
Upgraded d3 version to ^5 to fix issue #71 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-digraph",
   "description": "directed graph react component",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "keywords": [
     "uber-library",
     "babel",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-dom": "^16.3.0"
   },
   "dependencies": {
-    "d3": "^4.13.0",
+    "d3": "^5.7.0",
     "radium": "^0.24.1",
     "react-icons": "^2.2.1"
   },
@@ -55,7 +55,6 @@
     "opn-cli": "3.1.0",
     "prop-types": "^15.6.0",
     "react": "^16.4.2",
-    "react-addons-test-utils": "^15.6.2",
     "react-dom": "^16.4.2",
     "sinon": "^4.0.1",
     "tape": "^4.0.0"


### PR DESCRIPTION
Yarn installs a broken version of d3 using 4.13.0, but it doesn't break with 5.7.0, so I've upgraded d3 and ran various checks in the UI and tests. Also removed an unnecessary dependency.