### PR TITLE
Exclude coverage from published module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .*
 src/
+coverage/
 dist/test/
 dist/examples/
 example.gif


### PR DESCRIPTION
Having it in the module seems to have no advantage. This also causes the phabricator-jenkins-plugin to catch this coverage file to detect this as the coverage file used in our repo.

````
$ find . -name 'cobertura-coverage.xml'
./node_modules/react-digraph/coverage/cobertura-coverage.xml
````