### PR TITLE
There was a missing d3.event from last PR

### DIFF
--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -489,7 +489,7 @@ class GraphView extends Component {
 
     if(d3.event.target.tagName != 'path') return false; // If the handle is clicked
 
-    const xycoords = d3.mouse(event.target);
+    const xycoords = d3.mouse(d3.event.target);
     const target = this.props.getViewNode(d.target);
     const dist = getDistance({x: xycoords[0], y: xycoords[1]}, target);
 


### PR DESCRIPTION
I forgot to add this `d3.event` and Now everything works fine except when you select an Edge.
This PR solves this last issue.