### PR TITLE
Adding webpack-build-analyzer to react-digraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "style-loader": "^0.21.0",
     "uglifyjs-webpack-plugin": "^2.0.1",
     "webpack": "^4.26.1",
+    "webpack-bundle-analyzer": "3.0.4",
     "webpack-cli": "^3.1.2"
   },
   "scripts": {
@@ -109,7 +110,8 @@
     "serve": "npm run live-serve",
     "test": "jest",
     "view-cover": "npm run cover -- --report=html && opn ./coverage/index.html",
-    "package": "npm-run-all clean lint test build build:prod"
+    "package": "npm-run-all clean lint test build build:prod",
+    "analyze-bundle": "babel-node ./tools/analyzeBundle.js"
   },
   "jest": {
     "testURL": "http://localhost",

--- a/tools/analyzeBundle.js
+++ b/tools/analyzeBundle.js
@@ -1,0 +1,16 @@
+import webpack from 'webpack';
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+import config from '../webpack.prod';
+
+config.plugins.push(new BundleAnalyzerPlugin());
+process.env.NODE_ENV = 'production';
+
+const compiler = webpack(config);
+
+compiler.run((error, stats) => {
+  if (error) {
+    throw new Error(error);
+  }
+
+  console.log(stats);
+});


### PR DESCRIPTION
<img width="1432" alt="screen shot 2019-02-21 at 5 00 03 am" src="https://user-images.githubusercontent.com/2060731/53172585-8ee32f80-359a-11e9-98d4-d5ad44e04692.png">
☝️ example output of `yarn analyze-bundle`


Adding webpack-build-analyzer to react-digraph, and wiring up the necessary tooling
**How to use this**:

1. install via `yarn` or `npm install`
2. run `yarn analyze-bundle` or `npm run analyze-bundle`
3. once the analyzer is finished, it will open a new browser tab with the results 

Resolved #106