### PR TITLE
Allow setting initial viewBox in props, to start on an other zoom level

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ All props are detailed below.
 | zoomDur             | number                  | false     | Duration of zoom transition.                              |
 | showGraphControls   | boolean                 | false     | Whether to show zoom controls.                            |
 | layoutEngineType    | typeof LayoutEngineType | false     | Uses a pre-programmed layout engine, such as 'SnapToGrid' |
+| initialBBox         | typeof IBBox            | false     | If specified, initial render graph using the given bounding box|
 
 ### onCreateNode
 You have access to d3 mouse event in `onCreateNode` function.
@@ -294,6 +295,7 @@ Prop Types:
   ) => any;
   renderNodeText?: (data: any, id: string | number, isSelected: boolean) => any;
   layoutEngineType?: LayoutEngineType;
+  initialBBox?: IBBox;
 ```
 
 ## Deprecation Notes

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -19,6 +19,13 @@ import { type LayoutEngineType } from '../utilities/layout-engine/layout-engine-
 import { type IEdge, type ITargetPosition } from './edge';
 import { type INode } from './node';
 
+export type IBBox = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
 export type IGraphViewProps = {
   backgroundFillId?: string;
   edges: any[];
@@ -67,4 +74,5 @@ export type IGraphViewProps = {
   ) => any;
   afterRenderEdge?: (id: string, element: any, edge: IEdge, edgeContainer: any, isEdgeSelected: boolean) => void;
   renderNodeText?: (data: any, id: string | number, isSelected: boolean) => any;
+  initialBBox: IBBox;
 };

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -62,7 +62,6 @@ type IGraphViewState = {
   documentClicked: boolean;
   svgClicked: boolean;
   focused: boolean;
-  initialBBox: IBBox;
 };
 
 class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
@@ -175,6 +174,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   }
 
   componentDidMount() {
+    const { initialBBox, zoomDelay, minZoom, maxZoom } = this.props;
     // TODO: can we target the element rather than the document?
     document.addEventListener('keydown', this.handleWrapperKeydown);
     document.addEventListener('click', this.handleDocumentClick);
@@ -182,7 +182,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     this.zoom = d3
       .zoom()
       .filter(this.zoomFilter)
-      .scaleExtent([this.props.minZoom || 0, this.props.maxZoom || 0])
+      .scaleExtent([minZoom || 0, maxZoom || 0])
       .on('start', this.handleZoomStart)
       .on('zoom', this.handleZoom)
       .on('end', this.handleZoomEnd);
@@ -196,19 +196,22 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       .call(this.zoom);
 
     this.selectedView = d3.select(this.view);
-    if(this.props.initialBBox)
-      this.handleZoomToFitImpl(this.props.initialBBox, 0);
+
+    if(initialBBox) {
+      // If initialBBox is set, we don't compute the zoom and don't do any transition.
+      this.handleZoomToFitImpl(initialBBox, 0);
+      this.renderView();
+      return;
+    }
+
     // On the initial load, the 'view' <g> doesn't exist until componentDidMount.
     // Manually render the first view.
     this.renderView();
-
-    if (!this.props.initialBBox) {
-      setTimeout(() => {
-        if (this.viewWrapper != null) {
-          this.handleZoomToFit();
-        }
-      }, this.props.zoomDelay);
-    }
+    setTimeout(() => {
+      if (this.viewWrapper != null) {
+        this.handleZoomToFit();
+      }
+    }, zoomDelay);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
The graph is initially render in the default view box, then the zoom fits to screen in a transition.

The goal of this feature request is to have the possibility to provide an initial view box instead of zooming to fit screen 