### PR TITLE
Possibility to not rotate edge handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ All props are detailed below.
 | zoomDur             | number                  | false     | Duration of zoom transition.                              |
 | showGraphControls   | boolean                 | false     | Whether to show zoom controls.                            |
 | layoutEngineType    | typeof LayoutEngineType | false     | Uses a pre-programmed layout engine, such as 'SnapToGrid' |
+| rotateEdgeHandle    | boolean                 | false     | Weather to rotate edge handle with edge when a node is moved |
 
 ### onCreateNode
 You have access to d3 mouse event in `onCreateNode` function.
@@ -294,6 +295,7 @@ Prop Types:
   ) => any;
   renderNodeText?: (data: any, id: string | number, isSelected: boolean) => any;
   layoutEngineType?: LayoutEngineType;
+  rotateEdgeHandle?: boolean;
 ```
 
 ## Deprecation Notes

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ All props are detailed below.
 | zoomDur             | number                  | false     | Duration of zoom transition.                              |
 | showGraphControls   | boolean                 | false     | Whether to show zoom controls.                            |
 | layoutEngineType    | typeof LayoutEngineType | false     | Uses a pre-programmed layout engine, such as 'SnapToGrid' |
-| rotateEdgeHandle    | boolean                 | false     | Weather to rotate edge handle with edge when a node is moved |
+| rotateEdgeHandle    | boolean                 | false     | Whether to rotate edge handle with edge when a node is moved |
 
 ### onCreateNode
 You have access to d3 mouse event in `onCreateNode` function.

--- a/src/components/edge.js
+++ b/src/components/edge.js
@@ -49,12 +49,14 @@ type IEdgeProps = {
   isSelected: boolean;
   nodeKey: string;
   viewWrapperElem: HTMLDivElement;
+  rotateEdgeHandle: true;
 };
 
 class Edge extends React.Component<IEdgeProps> {
   static defaultProps = {
     edgeHandleSize: 50,
-    isSelected: false
+    isSelected: false,
+    rotateEdgeHandle: true,
   };
 
   static getTheta(pt1: any, pt2: any) {
@@ -466,7 +468,7 @@ class Edge extends React.Component<IEdgeProps> {
   }
 
   getEdgeHandleRotation = (negate: any = false) => {
-    let rotated = false
+    let rotated = false;
     const src = this.props.sourceNode;
     const trg = this.props.targetNode;
     let theta = Edge.getTheta(src, trg) * 180 / Math.PI;
@@ -482,7 +484,7 @@ class Edge extends React.Component<IEdgeProps> {
 
   getEdgeHandleTransformation = () => {
     const translation = this.getEdgeHandleTranslation();
-    const [ rotation, ]= this.getEdgeHandleRotation();
+    const rotation = this.props.rotateEdgeHandle ? this.getEdgeHandleRotation()[0] : '';
     const offset = this.getEdgeHandleOffsetTranslation();
     return `${translation} ${rotation} ${offset}`;
   }
@@ -546,7 +548,7 @@ class Edge extends React.Component<IEdgeProps> {
   }
 
   render() {
-    const { data, edgeTypes, edgeHandleSize, viewWrapperElem } = this.props;
+    const { data, edgeTypes, edgeHandleSize, viewWrapperElem, rotateEdgeHandle } = this.props;
     if (!viewWrapperElem) {
       return null;
     }

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -67,4 +67,5 @@ export type IGraphViewProps = {
   ) => any;
   afterRenderEdge?: (id: string, element: any, edge: IEdge, edgeContainer: any, isEdgeSelected: boolean) => void;
   renderNodeText?: (data: any, id: string | number, isSelected: boolean) => any;
+  rotateEdgeHandle?: boolean;
 };

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -72,7 +72,8 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     readOnly: false,
     showGraphControls: true,
     zoomDelay: 1000,
-    zoomDur: 750
+    zoomDur: 750,
+    rotateEdgeHandle: true,
   };
 
   static getDerivedStateFromProps(nextProps: IGraphViewProps, prevState: IGraphViewState) {
@@ -1122,6 +1123,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
         nodeKey={nodeKey}
         viewWrapperElem={this.viewWrapper.current}
         isSelected={this.isEdgeSelected(edge)}
+        rotateEdgeHandle={this.props.rotateEdgeHandle}
       />
     );
   }


### PR DESCRIPTION
In some cases, we may want to prevent the edge handles to rotate at the same times as the arrow, and leave the direction of the handle fixed.
-> provide a prop to the graph-view to disable the rotation