### PR TITLE
Add event handler when user clicks on the graph background

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ All props are detailed below.
 | onCreateEdge        | func                    | true      | Called when an edge is created.                           |
 | onSwapEdge          | func                    | true      | Called when an edge 'target' is swapped.                  |
 | onDeleteEdge        | func                    | true      | Called when an edge is deleted.                           |
+| onBackgroundClick   | func                    | false     | Called when the background is clicked.                    |
 | canDeleteNode       | func                    | false     | Called before a node is deleted.                          |
 | canCreateEdge       | func                    | false     | Called before an edge is created.                         |
 | canDeleteEdge       | func                    | false     | Called before an edge is deleted.                         |
@@ -268,6 +269,7 @@ Prop Types:
   nodeSubtypes: any;
   edgeTypes: any;
   selected: any;
+  onBackgroundClick?: (x: number, y: number) => void;
   onDeleteNode: (selected: any, nodeId: string, nodes: any[]) => void;
   onSelectNode: (node: INode | null) => void;
   onCreateNode: (x: number, y: number, event: object) => void;

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -45,6 +45,7 @@ export type IGraphViewProps = {
   canCreateEdge?: (startNode?:INode, endNode?:INode) => boolean;
   canDeleteEdge?: (selected: any) => boolean;
   canDeleteNode?: (selected: any) => boolean;
+  onBackgroundClick?: (x: number, y: number) => void;
   onCopySelected?: () => void;
   onCreateEdge: (sourceNode: INode, targetNode: INode) => void;
   onCreateNode: (x: number, y: number) => void;

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -523,6 +523,10 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
         svgClicked: true
       });
     } else {
+      if(!d3.event.shiftKey && this.props.onBackgroundClick) {
+        const xycoords = d3.mouse(d3.event.target);
+        this.props.onBackgroundClick(xycoords[0], xycoords[1], d3.event);
+      }
       const previousSelection = (this.state.selectedNodeObj && this.state.selectedNodeObj.node) || null;
       const previousSelectionIndex = (this.state.selectedNodeObj && this.state.selectedNodeObj.index) || -1;
 


### PR DESCRIPTION
When user clicks on the graph background, call props.onBackgroundClick
with parameters (x, y)