### PR TITLE
Add panToNode/panToEdge imperative methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,14 @@ Prop Types:
   layoutEngineType?: LayoutEngineType;
 ```
 
+## Imperative API
+You can call these methods on the GraphView class using a ref.
+
+| Method            | Type                                      | Notes                                                                       |
+| ------------------|:-----------------------------------------:|  :-------------------------------------------------------------------------:|
+| panToNode         | (id: string) => void                      | Center the node given by `id` within the viewport.                          |
+| panToEdge         | (source: string, target: string) => void  | Center the edge between `source` and `target` node IDs within the viewport. |
+
 ## Deprecation Notes
 
 | Prop                | Type    | Required  | Notes                                     |

--- a/README.md
+++ b/README.md
@@ -299,10 +299,10 @@ Prop Types:
 ## Imperative API
 You can call these methods on the GraphView class using a ref.
 
-| Method            | Type                                      | Notes                                                                       |
-| ------------------|:-----------------------------------------:|  :-------------------------------------------------------------------------:|
-| panToNode         | (id: string) => void                      | Center the node given by `id` within the viewport.                          |
-| panToEdge         | (source: string, target: string) => void  | Center the edge between `source` and `target` node IDs within the viewport. |
+| Method            | Type                                                      | Notes                                                                       |
+| ------------------|:---------------------------------------------------------:|  :-------------------------------------------------------------------------:|
+| panToNode         | (id: string, zoom?: boolean) => void                      | Center the node given by `id` within the viewport, optionally zoom in to fit it. |
+| panToEdge         | (source: string, target: string, zoom?: boolean) => void  | Center the edge between `source` and `target` node IDs within the viewport, optionally zoom in to fit it.  |
 
 ## Deprecation Notes
 

--- a/__tests__/components/graph-view.test.js
+++ b/__tests__/components/graph-view.test.js
@@ -939,9 +939,15 @@ describe('GraphView component', () => {
     });
 
     it('modifies the zoom to pan to the element', () => {
-      instance.panToEntity(entity);
+      instance.panToEntity(entity, false);
       expect(entity.getBBox).toHaveBeenCalled();
       expect(instance.setZoom).toHaveBeenCalledWith(0.4, 168, 186, 750);
+    });
+
+    it('modifies the zoom to pan and zoom to the element', () => {
+      instance.panToEntity(entity, true);
+      expect(entity.getBBox).toHaveBeenCalled();
+      expect(instance.setZoom).toHaveBeenCalledWith(1.125, 19.375, 70, 750);
     });
   });
 
@@ -958,7 +964,7 @@ describe('GraphView component', () => {
 
     it('calls panToEntity on the appropriate node', () => {
       instance.panToNode('a1');
-      expect(instance.panToEntity).toHaveBeenCalledWith(entity);
+      expect(instance.panToEntity).toHaveBeenCalledWith(entity, false);
     });
   });
 
@@ -975,7 +981,7 @@ describe('GraphView component', () => {
 
     it('calls panToEntity on the appropriate edge', () => {
       instance.panToEdge('a1', 'a2');
-      expect(instance.panToEntity).toHaveBeenCalledWith(entity);
+      expect(instance.panToEntity).toHaveBeenCalledWith(entity, false);
     });
   });
 });

--- a/__tests__/components/graph-view.test.js
+++ b/__tests__/components/graph-view.test.js
@@ -897,4 +897,85 @@ describe('GraphView component', () => {
       expect(instance.dragEdge).toHaveBeenCalled();
     });
   });
+
+  describe('panToEntity method', () => {
+    const entity = document.createElement('g');
+    entity.getBBox = jasmine.createSpy().and.returnValue({ width: 400, height: 300, x: 5, y: 10 });
+    beforeEach(() => {
+      spyOn(instance, 'setZoom');
+      instance.viewWrapper = {
+        current: document.createElement('div')
+      }
+      // this gets around instance.viewWrapper.client[Var] being readonly, we need to customize the object
+      let globalWidth = 0;
+      Object.defineProperty(instance.viewWrapper.current, 'clientWidth', {
+        get: () => {
+          return globalWidth;
+        },
+        set: (clientWidth) => {
+          globalWidth = clientWidth;
+        }
+      });
+      let globalHeight = 0;
+      Object.defineProperty(instance.viewWrapper.current, 'clientHeight', {
+        get: () => {
+          return globalHeight;
+        },
+        set: (clientHeight) => {
+          globalHeight = clientHeight;
+        }
+      });
+      instance.viewWrapper.current.clientWidth = 500;
+      instance.viewWrapper.current.clientHeight = 500;
+      instance.setState({
+        viewTransform: {
+          k: 0.4,
+          x: 50,
+          y: 50
+        }
+      });
+      instance.entities = document.createElement('g');
+      instance.entities.appendChild(entity);
+    });
+
+    it('modifies the zoom to pan to the element', () => {
+      instance.panToEntity(entity);
+      expect(entity.getBBox).toHaveBeenCalled();
+      expect(instance.setZoom).toHaveBeenCalledWith(0.4, 168, 186, 750);
+    });
+  });
+
+  describe('panToNode method', () => {
+    const entity = document.createElement('g');
+    entity.id = "node-a1-container";
+
+    beforeEach(() => {
+      instance.panToEntity = jest.fn();
+
+      instance.entities = document.createElement('g');
+      instance.entities.appendChild(entity);
+    });
+
+    it('calls panToEntity on the appropriate node', () => {
+      instance.panToNode('a1');
+      expect(instance.panToEntity).toHaveBeenCalledWith(entity);
+    });
+  });
+
+  describe('panToEdge method', () => {
+    const entity = document.createElement('g');
+    entity.id = "edge-a1-a2-container";
+
+    beforeEach(() => {
+      instance.panToEntity = jest.fn();
+
+      instance.entities = document.createElement('g');
+      instance.entities.appendChild(entity);
+    });
+
+    it('calls panToEntity on the appropriate edge', () => {
+      instance.panToEdge('a1', 'a2');
+      expect(instance.panToEntity).toHaveBeenCalledWith(entity);
+    });
+  });
 });

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1254,9 +1254,10 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   }
 
   /* Imperative API */
-  panToEntity(entity: IEdge | INode) {
+  panToEntity(entity: IEdge | INode, zoom: boolean) {
     const parent = this.viewWrapper.current;
     const entityBBox = entity ? entity.getBBox() : null;
+    const maxZoom = this.props.maxZoom || 2;
 
     if (!parent || !entityBBox) {
       return;
@@ -1274,23 +1275,30 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     const x = entityBBox.x + entityBBox.width / 2;
     const y = entityBBox.y + entityBBox.height / 2;
 
+    if (zoom) {
+      next.k = 0.9 / Math.max(entityBBox.width / width, entityBBox.height / height);
+      if (next.k > maxZoom) {
+        next.k = maxZoom;
+      }
+    }
+
     next.x = width / 2 - next.k * x;
     next.y = height / 2 - next.k * y;
 
     this.setZoom(next.k, next.x, next.y, this.props.zoomDur);
   }
 
-  panToNode(id: string) {
+  panToNode(id: string, zoom?: boolean = false) {
     if (!this.entities) {
       return;
     }
 
     const node = this.entities.querySelector(`#node-${id}-container`);
 
-    this.panToEntity(node);
+    this.panToEntity(node, zoom);
   }
 
-  panToEdge(source: string, target: string) {
+  panToEdge(source: string, target: string, zoom?: boolean = false) {
     if (!this.entities) {
       return;
     }
@@ -1299,7 +1307,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       `#edge-${source}-${target}-container`
     );
 
-    this.panToEntity(edge);
+    this.panToEntity(edge, zoom);
   }
 }
 

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1252,6 +1252,55 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       </div>
     );
   }
+
+  /* Imperative API */
+  panToEntity(entity: IEdge | INode) {
+    const parent = this.viewWrapper.current;
+    const entityBBox = entity ? entity.getBBox() : null;
+
+    if (!parent || !entityBBox) {
+      return;
+    }
+
+    const width = parent.clientWidth;
+    const height = parent.clientHeight;
+
+    const next = {
+      k: this.state.viewTransform.k,
+      x: 0,
+      y: 0,
+    };
+
+    const x = entityBBox.x + entityBBox.width / 2;
+    const y = entityBBox.y + entityBBox.height / 2;
+
+    next.x = width / 2 - next.k * x;
+    next.y = height / 2 - next.k * y;
+
+    this.setZoom(next.k, next.x, next.y, this.props.zoomDur);
+  }
+
+  panToNode(id: string) {
+    if (!this.entities) {
+      return;
+    }
+
+    const node = this.entities.querySelector(`#node-${id}-container`);
+
+    this.panToEntity(node);
+  }
+
+  panToEdge(source: string, target: string) {
+    if (!this.entities) {
+      return;
+    }
+
+    const edge = this.entities.querySelector(
+      `#edge-${source}-${target}-container`
+    );
+
+    this.panToEntity(edge);
+  }
 }
 
 export default GraphView;

--- a/src/examples/app.scss
+++ b/src/examples/app.scss
@@ -61,7 +61,7 @@ button {
   background-color: #fff;
   padding: 10px;
 
-  .layout-engine {
+  .layout-engine, .pan-list {
     display: inline-block;
     > span {
       margin-right: 5px;

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -437,6 +437,11 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
 
   handleChangeLayoutEngineType = (event: any) => {
     this.setState({ layoutEngineType: (event.target.value: LayoutEngineType | 'None') });
+}
+
+  onSelectPanNode = (event: any) => {
+    if (this.GraphView)
+      this.GraphView.panToNode(event.target.value);
   }
 
   /*
@@ -468,6 +473,12 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
               <option value={undefined}>None</option>
               <option value={'SnapToGrid'}>Snap to Grid</option>
               <option value={'VerticalTree'}>Vertical Tree</option>
+            </select>
+          </div>
+          <div className="pan-list">
+          <span>Pan To:</span>
+            <select onChange={this.onSelectPanNode}>
+              {nodes.map(node => <option key={node[NODE_KEY]} value={node[NODE_KEY]}>{node.title}</option>)}
             </select>
           </div>
         </div>

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -441,7 +441,7 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
 
   onSelectPanNode = (event: any) => {
     if (this.GraphView)
-      this.GraphView.panToNode(event.target.value);
+      this.GraphView.panToNode(event.target.value, true);
   }
 
   /*


### PR DESCRIPTION
This allows users to imperatively (i.e., using a ref to GraphView) pan to a node or edge within the graph. The math in the panToEntity function and its tests are based on the handleZoomToFit function, just without zooming and specific to a single element's bbox instead of all elements.
Adds some basic usage to the example app.