### PR TITLE
add onOverrideableClick callback to GraphView

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ All props are detailed below.
 | onSwapEdge          | func                    | true      | Called when an edge 'target' is swapped.                  |
 | onDeleteEdge        | func                    | true      | Called when an edge is deleted.                           |
 | onBackgroundClick   | func                    | false     | Called when the background is clicked.                    |
+| onOverrideableClick | func                    | false     | Called when a node is clicked and returns true if the event should be overridden |
 | canDeleteNode       | func                    | false     | Called before a node is deleted.                          |
 | canCreateEdge       | func                    | false     | Called before an edge is created.                         |
 | canDeleteEdge       | func                    | false     | Called before an edge is deleted.                         |
@@ -285,6 +286,7 @@ Prop Types:
   canDeleteEdge?: (selected: any) => boolean;
   canCreateEdge?: (startNode?: INode, endNode?: INode) => boolean;
   afterRenderEdge?: (id: string, element: any, edge: IEdge, edgeContainer: any, isEdgeSelected: boolean) => void;
+  onOverrideableClick?: (event: any) => boolean;
   onUndo?: () => void;
   onCopySelected?: () => void;
   onPasteSelected?: () => void;

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -65,6 +65,7 @@ export type IGraphViewProps = {
   onSelectEdge: (selectedEdge: IEdge) => void,
   onSelectNode: (node: INode | null, event: any) => void,
   onSwapEdge: (sourceNode: INode, targetNode: INode, edge: IEdge) => void,
+  onOverrideableClick?: (event: any) => boolean,
   onUndo?: () => void,
   onUpdateNode: (node: INode) => void,
   renderBackground?: (gridSize?: number) => any,

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -67,6 +67,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     canCreateEdge: (startNode?: INode, endNode?: INode) => true,
     canDeleteEdge: () => true,
     canDeleteNode: () => true,
+    onOverrideableClick: () => false,
     edgeArrowSize: 8,
     gridSpacing: 36,
     layoutEngineType: 'None',
@@ -515,6 +516,16 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     // inform consumer
     this.props.onDeleteEdge(selectedEdge, newEdgesArr);
   }
+
+  handleOverrideableClick = (event: any) => {
+    const { readOnly, onOverrideableClick } = this.props;
+
+    if (readOnly) {
+      return false;
+    }
+
+    return onOverrideableClick(event) || false;
+  };
 
   handleDelete = (selected: IEdge | INode) => {
     const { canDeleteNode, canDeleteEdge, readOnly } = this.props;
@@ -1215,6 +1226,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
         onNodeMove={this.handleNodeMove}
         onNodeUpdate={this.handleNodeUpdate}
         onNodeSelected={this.handleNodeSelected}
+        onOverrideableClick={this.handleOverrideableClick}
         renderNode={renderNode}
         renderNodeText={renderNodeText}
         isSelected={this.state.selectedNodeObj.node === node}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -42,6 +42,7 @@ declare module 'react-digraph' {
     onNodeMove: (point: IPoint, id: string, shiftKey: boolean) => void;
     onNodeSelected: (data: any, id: string, shiftKey: boolean) => void;
     onNodeUpdate: (point: IPoint, id: string, shiftKey: boolean) => void;
+    onOverrideableClick: (event: any) => boolean;
     renderNode?: (
       nodeRef: any,
       data: any,
@@ -125,6 +126,7 @@ declare module 'react-digraph' {
     onSelectNode: (node: INode | null) => void;
     onSwapEdge: (sourceNode: INode, targetNode: INode, edge: IEdge) => void;
     onUndo?: () => void;
+    onOverrideableClick?: (event: any) => boolean;
     onUpdateNode: (node: INode) => void;
     renderBackground?: (gridSize?: number) => any;
     renderDefs?: () => any;


### PR DESCRIPTION
I have created an [issue](https://github.com/uber/react-digraph/issues/173) for a number of smaller changes I will be submitting. This is the solution for the first point on the issue:

> Ability to override click events to not trigger re-renders. This is needed so an `input` component can be used inside a node.

