### PR TITLE
Custom node intersection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ All props are detailed below.
 | onSwapEdge          | func                    | true      | Called when an edge 'target' is swapped.                  |
 | onDeleteEdge        | func                    | true      | Called when an edge is deleted.                           |
 | onBackgroundClick   | func                    | false     | Called when the background is clicked.                    |
+| onOverrideableClick | func                    | false     | Called when a node is clicked and returns true if the event should be overridden |
 | canDeleteNode       | func                    | false     | Called before a node is deleted.                          |
 | canCreateEdge       | func                    | false     | Called before an edge is created.                         |
 | canDeleteEdge       | func                    | false     | Called before an edge is deleted.                         |
@@ -285,6 +286,7 @@ Prop Types:
   canDeleteEdge?: (selected: any) => boolean;
   canCreateEdge?: (startNode?: INode, endNode?: INode) => boolean;
   afterRenderEdge?: (id: string, element: any, edge: IEdge, edgeContainer: any, isEdgeSelected: boolean) => void;
+  onOverrideableClick?: (event: any) => boolean;
   onUndo?: () => void;
   onCopySelected?: () => void;
   onPasteSelected?: () => void;

--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ All props are detailed below.
 | minZoom             | number                  | false     | Minimum zoom percentage.                                  |
 | maxZoom             | number                  | false     | Maximum zoom percentage.                                  |
 | nodeSize            | number                  | false     | Node bbox size.                                           |
+| nodeHeight          | number                  | false     | Node bbox height. Takes precedence over `nodeSize`        |
+| nodeWidth           | number                  | false     | Node bbox width. Takes precedence over `nodeSize`         |
 | edgeHandleSize      | number                  | false     | Edge handle size.                                         |
 | edgeArrowSize       | number                  | false     | Edge arrow size.                                          |
 | zoomDelay           | number                  | false     | Delay before zoom occurs.                                 |
@@ -236,7 +238,7 @@ All props are detailed below.
 | showGraphControls   | boolean                 | false     | Whether to show zoom controls.                            |
 | layoutEngineType    | typeof LayoutEngineType | false     | Uses a pre-programmed layout engine, such as 'SnapToGrid' |
 | rotateEdgeHandle    | boolean                 | false     | Whether to rotate edge handle with edge when a node is moved |
-| centerNodeOnMove    | boolean                 | false     | Weather the node should be centered on cursor when moving a node    |
+| centerNodeOnMove    | boolean                 | false     | Whether the node should be centered on cursor when moving a node    |
 | initialBBox         | typeof IBBox            | false     | If specified, initial render graph using the given bounding box|
 
 ### onCreateNode
@@ -259,6 +261,8 @@ Prop Types:
   readOnly?: boolean;
   maxTitleChars?: number;
   nodeSize?: number;
+  nodeHeight?: number;
+  nodeWidth?: number;
   edgeHandleSize?: number;
   edgeArrowSize?: number;
   zoomDelay?: number;
@@ -298,7 +302,7 @@ Prop Types:
     index: number,
     selected: boolean,
     hovered: boolean,
-    props: INodeComponentProps
+    nodeProps: INodeComponentProps
   ) => any;
   renderNodeText?: (data: any, id: string | number, isSelected: boolean) => any;
   layoutEngineType?: LayoutEngineType;

--- a/README.md
+++ b/README.md
@@ -297,7 +297,8 @@ Prop Types:
     data: any,
     index: number,
     selected: boolean,
-    hovered: boolean
+    hovered: boolean,
+    props: INodeComponentProps
   ) => any;
   renderNodeText?: (data: any, id: string | number, isSelected: boolean) => any;
   layoutEngineType?: LayoutEngineType;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "d3": "^5.7.0",
     "dagre": "^0.8.2",
     "fast-deep-equal": "^2.0.1",
-    "html-react-parser": "^0.6.1",
+    "html-react-parser": "^0.9.1",
     "kld-affine": "2.0.4",
     "kld-intersections": "^0.4.3",
     "line-intersect": "^2.1.1",

--- a/src/components/edge.js
+++ b/src/components/edge.js
@@ -411,15 +411,17 @@ class Edge extends React.Component<IEdgeProps> {
       return response;
     }
 
-    const foreignObj = viewWrapperElem.querySelector(
-      `foreignObject.digraph-foreign-node-${trg[nodeKey]}`
+    // If there is a custom rendered node, we use the className that `node.js`
+    // passes through as a prop in the `renderNode` method
+    const foreignNode = viewWrapperElem.querySelector(
+      `.digraph-foreign-node-${trg[nodeKey]}`
     );
 
-    if (foreignObj) {
+    if (foreignNode) {
       return {
         ...response,
         ...Edge.getRotatedRectIntersect(
-          foreignObj,
+          foreignNode,
           src,
           trg,
           includesArrow,

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -65,6 +65,7 @@ export type IGraphViewProps = {
   onSelectEdge: (selectedEdge: IEdge) => void,
   onSelectNode: (node: INode | null, event: any) => void,
   onSwapEdge: (sourceNode: INode, targetNode: INode, edge: IEdge) => void,
+  onOverrideableClick?: (event: any) => boolean,
   onUndo?: () => void,
   onUpdateNode: (node: INode) => void,
   renderBackground?: (gridSize?: number) => any,

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -67,6 +67,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     canCreateEdge: (startNode?: INode, endNode?: INode) => true,
     canDeleteEdge: () => true,
     canDeleteNode: () => true,
+    onOverrideableClick: () => false,
     edgeArrowSize: 8,
     gridSpacing: 36,
     layoutEngineType: 'None',
@@ -515,6 +516,16 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     // inform consumer
     this.props.onDeleteEdge(selectedEdge, newEdgesArr);
   }
+
+  handleOverrideableClick = (event: any) => {
+    const { readOnly, onOverrideableClick } = this.props;
+
+    if (readOnly) {
+      return false;
+    }
+
+    return onOverrideableClick(event) || false;
+  };
 
   handleDelete = (selected: IEdge | INode) => {
     const { canDeleteNode, canDeleteEdge, readOnly } = this.props;
@@ -1215,6 +1226,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
         onNodeMove={this.handleNodeMove}
         onNodeUpdate={this.handleNodeUpdate}
         onNodeSelected={this.handleNodeSelected}
+        onOverrideableClick={this.handleOverrideableClick}
         renderNode={renderNode}
         renderNodeText={renderNodeText}
         isSelected={this.state.selectedNodeObj.node === node}

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -961,7 +961,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   }
 
   dragEdge(draggedEdge?: IEdge) {
-    const { nodeSize, nodeKey } = this.props;
+    const { nodeKey } = this.props;
 
     draggedEdge = draggedEdge || this.state.draggedEdge;
 
@@ -975,7 +975,6 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       y: mouseCoordinates[1],
     };
     const off = Edge.calculateOffset(
-      nodeSize,
       (this.getNodeById(draggedEdge.source): any).node,
       targetPosition,
       nodeKey
@@ -1206,6 +1205,8 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       nodeTypes,
       nodeSubtypes,
       nodeSize,
+      nodeHeight,
+      nodeWidth,
       renderNode,
       renderNodeText,
       nodeKey,
@@ -1219,6 +1220,8 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
         data={node}
         nodeTypes={nodeTypes}
         nodeSize={nodeSize}
+        nodeHeight={nodeHeight}
+        nodeWidth={nodeWidth}
         nodeKey={nodeKey}
         nodeSubtypes={nodeSubtypes}
         onNodeMouseEnter={this.handleNodeMouseEnter}
@@ -1328,14 +1331,13 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     const targetNodeMapNode = this.getNodeById(edge.target);
     const targetNode = targetNodeMapNode ? targetNodeMapNode.node : null;
     const targetPosition = edge.targetPosition;
-    const { edgeTypes, edgeHandleSize, nodeSize, nodeKey } = this.props;
+    const { edgeTypes, edgeHandleSize, nodeKey } = this.props;
 
     return (
       <Edge
         data={edge}
         edgeTypes={edgeTypes}
         edgeHandleSize={edgeHandleSize}
-        nodeSize={nodeSize}
         sourceNode={sourceNode}
         targetNode={targetNode || targetPosition}
         nodeKey={nodeKey}

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -74,7 +74,7 @@ type INodeProps = {
     id: string,
     selected: boolean,
     hovered: boolean,
-    props: INodeComponentProps
+    nodeProps: INodeComponentProps
   ) => any,
   renderNodeText?: (data: any, id: string | number, isSelected: boolean) => any,
   isSelected: boolean,
@@ -350,12 +350,16 @@ class Node extends React.Component<INodeProps, INodeState> {
       Node.getNodeSubtypeXlinkHref(data, nodeSubtypes) || '';
 
     props.xlinkHref = nodeTypeXlinkHref;
-    props.className = `${nodeClassName} digraph-foreign-node-${data[nodeKey]}`;
+    props.className = nodeClassName;
     props['data-index'] = index;
     props.x = -props.width / 2;
     props.y = -props.height / 2;
 
     if (renderNode) {
+      // Add this classname to the rendered node props as it is used by the
+      // `edge.js` intersection detection logic
+      props.className = `${props.className} digraph-foreign-node-${data[nodeKey]}`;
+
       // Originally: graphView, domNode, datum, index, elements.
       return renderNode(
         this.nodeRef,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -42,6 +42,7 @@ declare module 'react-digraph' {
     onNodeMove: (point: IPoint, id: string, shiftKey: boolean) => void;
     onNodeSelected: (data: any, id: string, shiftKey: boolean) => void;
     onNodeUpdate: (point: IPoint, id: string, shiftKey: boolean) => void;
+    onOverrideableClick: (event: any) => boolean;
     renderNode?: (
       nodeRef: any,
       data: any,
@@ -125,6 +126,7 @@ declare module 'react-digraph' {
     onSelectNode: (node: INode | null) => void;
     onSwapEdge: (sourceNode: INode, targetNode: INode, edge: IEdge) => void;
     onUndo?: () => void;
+    onOverrideableClick?: (event: any) => boolean;
     onUpdateNode: (node: INode) => void;
     renderBackground?: (gridSize?: number) => any;
     renderDefs?: () => any;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -47,6 +47,8 @@ declare module 'react-digraph' {
     opacity?: number;
     nodeKey: string;
     nodeSize?: number;
+    nodeHeight?: number;
+    nodeWidth?: number;
     onNodeMouseEnter: (event: any, data: any, hovered: boolean) => void;
     onNodeMouseLeave: (event: any, data: any) => void;
     onNodeMove: (point: IPoint, id: string, shiftKey: boolean) => void;
@@ -91,7 +93,6 @@ declare module 'react-digraph' {
     data: IEdge;
     edgeTypes: any; // TODO: create an edgeTypes interface
     edgeHandleSize?: number;
-    nodeSize?: number;
     sourceNode: INode | null;
     targetNode: INode | ITargetPosition;
     isSelected: boolean;
@@ -117,6 +118,8 @@ declare module 'react-digraph' {
     nodeKey: string;
     nodes: any[];
     nodeSize?: number;
+    nodeHeight?: number;
+    nodeWidth?: number;
     nodeSubtypes: any;
     nodeTypes: any;
     readOnly?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -29,6 +29,16 @@ declare module 'react-digraph' {
     y: number;
   };
 
+  export type INodeComponentProps = {
+    height: number,
+    width: number,
+    x: number,
+    y: number,
+    xlinkHref: string,
+    className: string,
+    'data-index': number
+  };
+
   export type INodeProps = {
     data: INode;
     id: string;
@@ -48,7 +58,8 @@ declare module 'react-digraph' {
       data: any,
       id: string,
       selected: boolean,
-      hovered: boolean
+      hovered: boolean,
+      props: INodeComponentProps
     ) => any;
     renderNodeText?: (
       data: any,
@@ -135,7 +146,8 @@ declare module 'react-digraph' {
       data: any,
       id: string,
       selected: boolean,
-      hovered: boolean
+      hovered: boolean,
+      props: INodeComponentProps
     ) => any;
     afterRenderEdge?: (
       id: string,


### PR DESCRIPTION
This solves points 2 and 3 in my [issue](https://github.com/uber/react-digraph/issues/173). Point 1 is solved by an earlier PR (but the changes from that PR are included here as I branched off that other branch). I believe none of the changes are breaking, so this should only require a minor version bump :). I'm very open to feedback on design or implementation!

Some key changes:

- Upgraded `html-react-parser`. This was causing an earlier version of `react` to be used when linked into my app, resulting in two instances of react being bundled and breaking the react hooks feature.
- Added a new `nodeProps` argument to the `renderNode` method, allowing an easy pattern for rendering custom components in a way that the edges can detect their intersection points.

eg.

```js
renderNode = (ref, data, id, selected, hover, nodeProps) => (
    <foreignObject {...nodeProps} >
      <CustomComponent data={data} selected={selected} />
    </foreignObject>
);
```

- Removed unused `nodeSize` prop from the `Edge` component
- Refactored the `Edge.calculateOffset` to use an early-return pattern, which reduces the amount of conditional logic required. I've also added a check for the class that gets added to the `nodeProps` className when custom components are rendered. This allows the `width` and `height` of custom components to be calculated reliably
- Added optional `nodeHeight` and `nodeWidth` props to the `GraphView` and `Node` components, which override the `nodeSize` if specified. This is just to allow non-square custom components
