### PR TITLE
Added `types` property to enable Typescript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "license": "MIT",
   "main": "dist/main.min.js",
+  "types": "./typings/index.d.ts",
   "peerDependencies": {
     "react": "^16.4.1",
     "react-dom": "^16.4.1"


### PR DESCRIPTION
According to [Typescript Docs](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html), it is best practice to include the `types` property to point Typescript to the typings file of your package.