### PR TITLE
Fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ npm-debug.log
 
 .DS_Store
 *.log
-.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "flow.useNPMPackagedFlow": true,
+  "javascript.validate.enable": false,
+  "typescript.validate.enable": false,
+  "search.exclude": {
+    "**/flow-typed": true,
+    "**/node_modules": true,
+    "**/bower_components": true,
+    "**/dist*": true
+  },
+  "prettier.eslintIntegration": true,
+  "eslint.enable": true,
+  "workbench.colorCustomizations": {},
+  "editor.tabSize": 2
+}

--- a/__tests__/components/background.test.js
+++ b/__tests__/components/background.test.js
@@ -40,7 +40,7 @@ describe('Background component', () => {
 
   describe('renderBackground method', () => {
     it('uses the renderBackground callback', () => {
-      const renderBackground = jasmine.createSpy().and.returnValue('test');
+      const renderBackground = jest.fn().mockReturnValue('test');
 
       output.setProps({
         gridSize: 1000,

--- a/__tests__/components/graph-controls.test.js
+++ b/__tests__/components/graph-controls.test.js
@@ -10,18 +10,31 @@ describe('GraphControls component', () => {
   let output = null;
   let zoomToFit;
   let modifyZoom;
+
   beforeEach(() => {
-    zoomToFit = jasmine.createSpy();
-    modifyZoom = jasmine.createSpy();
-    output = shallow(<GraphControls zoomLevel={0} zoomToFit={zoomToFit} modifyZoom={modifyZoom} />);
+    zoomToFit = jest.fn();
+    modifyZoom = jest.fn();
+    output = shallow(
+      <GraphControls
+        zoomLevel={0}
+        zoomToFit={zoomToFit}
+        modifyZoom={modifyZoom}
+      />
+    );
   });
 
   describe('render method', () => {
     it('renders', () => {
       expect(output.props().className).toEqual('graph-controls');
-      expect(output.children().first().props().className).toEqual('slider-wrapper');
+      expect(
+        output
+          .children()
+          .first()
+          .props().className
+      ).toEqual('slider-wrapper');
 
       const rangeInput = output.find('input.slider');
+
       expect(rangeInput.length).toEqual(1);
       expect(rangeInput.props().type).toEqual('range');
       expect(rangeInput.props().min).toEqual(0);
@@ -33,9 +46,10 @@ describe('GraphControls component', () => {
     it('renders with a custom min and max zoom', () => {
       output.setProps({
         maxZoom: 0.9,
-        minZoom: 0
+        minZoom: 0,
       });
       const rangeInput = output.find('input.slider');
+
       expect(rangeInput.props().min).toEqual(0);
       expect(rangeInput.props().max).toEqual(100);
       expect(rangeInput.props().value).toEqual(0);
@@ -43,10 +57,11 @@ describe('GraphControls component', () => {
 
     it('zooms on change', () => {
       const rangeInput = output.find('input');
+
       rangeInput.simulate('change', {
         target: {
-          value: 55
-        }
+          value: 55,
+        },
       });
       expect(modifyZoom).toHaveBeenCalledWith(0.8925000000000001);
     });
@@ -56,8 +71,8 @@ describe('GraphControls component', () => {
     it('calls modifyZoom callback with the new zoom delta', () => {
       output.instance().zoom({
         target: {
-          value: 55
-        }
+          value: 55,
+        },
       });
       expect(modifyZoom).toHaveBeenCalledWith(0.8925000000000001);
     });
@@ -65,8 +80,8 @@ describe('GraphControls component', () => {
     it('does not call modifyZoom callback when the zoom level is greater than max', () => {
       output.instance().zoom({
         target: {
-          value: 101
-        }
+          value: 101,
+        },
       });
       expect(modifyZoom).not.toHaveBeenCalled();
     });
@@ -74,8 +89,8 @@ describe('GraphControls component', () => {
     it('does not call modifyZoom callback when the zoom level is less than min', () => {
       output.instance().zoom({
         target: {
-          value: -1
-        }
+          value: -1,
+        },
       });
       expect(modifyZoom).not.toHaveBeenCalled();
     });
@@ -84,6 +99,7 @@ describe('GraphControls component', () => {
   describe('zoomToSlider method', () => {
     it('converts a value to a decimal-based slider position', () => {
       const result = output.instance().zoomToSlider(10);
+
       expect(result).toEqual(729.6296296296296);
     });
   });

--- a/__tests__/components/graph-util.test.js
+++ b/__tests__/components/graph-util.test.js
@@ -1,7 +1,6 @@
 // @flow
 
 import GraphUtils from '../../src/utilities/graph-util';
-import { Edge } from '../../src';
 
 describe('GraphUtils class', () => {
   describe('getNodesMap method', () => {
@@ -127,11 +126,11 @@ describe('GraphUtils class', () => {
     it('removes an element using an id', () => {
       const fakeElement = {
         parentNode: {
-          removeChild: jasmine.createSpy(),
+          removeChild: jest.fn(),
         },
       };
 
-      spyOn(document, 'getElementById').and.returnValue(fakeElement);
+      jest.spyOn(document, 'getElementById').mockReturnValue(fakeElement);
       const result = GraphUtils.removeElementFromDom('fake');
 
       expect(fakeElement.parentNode.removeChild).toHaveBeenCalledWith(
@@ -141,7 +140,7 @@ describe('GraphUtils class', () => {
     });
 
     it("does nothing when it can't find the element", () => {
-      spyOn(document, 'getElementById').and.returnValue(undefined);
+      jest.spyOn(document, 'getElementById').mockReturnValue(undefined);
       const result = GraphUtils.removeElementFromDom('fake');
 
       expect(result).toEqual(false);
@@ -151,7 +150,7 @@ describe('GraphUtils class', () => {
   describe('findParent method', () => {
     it('returns the element if an element matches a selector', () => {
       const element = {
-        matches: jasmine.createSpy().and.returnValue(true),
+        matches: jest.fn().mockReturnValue(true),
       };
       const parent = GraphUtils.findParent(element, 'fake');
 
@@ -161,7 +160,7 @@ describe('GraphUtils class', () => {
     it('returns the parent if an element contains a parentNode property', () => {
       const element = {
         parentNode: {
-          matches: jasmine.createSpy().and.returnValue(true),
+          matches: jest.fn().mockReturnValue(true),
         },
       };
       const parent = GraphUtils.findParent(element, 'fake');
@@ -172,7 +171,7 @@ describe('GraphUtils class', () => {
     it('returns null when there is no match', () => {
       const element = {
         parentNode: {
-          matches: jasmine.createSpy().and.returnValue(false),
+          matches: jest.fn().mockReturnValue(false),
         },
       };
       const parent = GraphUtils.findParent(element, 'fake');

--- a/__tests__/components/graph-view.test.js
+++ b/__tests__/components/graph-view.test.js
@@ -3,9 +3,7 @@
 import * as d3 from 'd3';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-
 import { shallow } from 'enzyme';
-
 import Background from '../../src/components/background';
 import Defs from '../../src/components/defs';
 import GraphUtils from '../../src/utilities/graph-util';
@@ -42,45 +40,21 @@ describe('GraphView component', () => {
     edgeTypes = {};
     selected = null;
     nodeKey = 'id';
-    onDeleteNode = jasmine.createSpy();
-    onSelectNode = jasmine.createSpy();
-    onCreateNode = jasmine.createSpy();
-    onCreateEdge = jasmine.createSpy();
-    onDeleteEdge = jasmine.createSpy();
-    onUpdateNode = jasmine.createSpy();
-    onSwapEdge = jasmine.createSpy();
-    onSelectEdge = jasmine.createSpy();
-    ReactDOM.render = jasmine.createSpy();
+    onDeleteNode = jest.fn();
+    onSelectNode = jest.fn();
+    onCreateNode = jest.fn();
+    onCreateEdge = jest.fn();
+    onDeleteEdge = jest.fn();
+    onUpdateNode = jest.fn();
+    onSwapEdge = jest.fn();
+    onSelectEdge = jest.fn();
+    ReactDOM.render = jest.fn();
 
-    spyOn(document, 'querySelector').and.returnValue({
-      getBoundingClientRect: jasmine.createSpy().and.returnValue({
+    jest.spyOn(document, 'querySelector').mockReturnValue({
+      getBoundingClientRect: jest.fn().mockReturnValue({
         width: 0,
         height: 0,
       }),
-    });
-
-    // this gets around d3 being readonly, we need to customize the event object
-    let globalEvent = {
-      sourceEvent: {},
-    };
-
-    Object.defineProperty(d3, 'event', {
-      get: () => {
-        return globalEvent;
-      },
-      set: event => {
-        globalEvent = event;
-      },
-    });
-    let globalMouse = {};
-
-    Object.defineProperty(d3, 'mouse', {
-      get: () => {
-        return globalMouse;
-      },
-      set: mouse => {
-        globalMouse = mouse;
-      },
     });
 
     output = shallow(
@@ -102,7 +76,6 @@ describe('GraphView component', () => {
         onSwapEdge={onSwapEdge}
       />
     );
-
     instance = output.instance();
   });
 
@@ -151,7 +124,13 @@ describe('GraphView component', () => {
       graphControlsWrapper.classList.add('graph-controls-wrapper');
       instance.viewWrapper.current.appendChild(graphControlsWrapper);
 
-      spyOn(document, 'getElementById').and.returnValue(graphControlsWrapper);
+      jest
+        .spyOn(document, 'getElementById')
+        .mockReturnValue(graphControlsWrapper);
+    });
+
+    afterEach(() => {
+      document.getElementById.mockRestore();
     });
 
     it('does nothing when showGraphControls is false', () => {
@@ -179,7 +158,7 @@ describe('GraphView component', () => {
 
   describe('renderEdges method', () => {
     beforeEach(() => {
-      spyOn(instance, 'asyncRenderEdge');
+      jest.spyOn(instance, 'asyncRenderEdge');
     });
 
     it('does nothing when there are no entities', () => {
@@ -211,7 +190,7 @@ describe('GraphView component', () => {
         ],
       });
       // modifying the edges will call renderEdges, we need to reset this count.
-      instance.asyncRenderEdge.calls.reset();
+      instance.asyncRenderEdge.mockReset();
       instance.entities = [];
       instance.renderEdges();
       expect(instance.asyncRenderEdge).toHaveBeenCalledTimes(2);
@@ -220,8 +199,8 @@ describe('GraphView component', () => {
 
   describe('syncRenderEdge method', () => {
     beforeEach(() => {
-      spyOn(instance, 'renderEdge');
-      spyOn(instance, 'getEdgeComponent').and.returnValue('blah');
+      jest.spyOn(instance, 'renderEdge');
+      jest.spyOn(instance, 'getEdgeComponent').mockReturnValue('blah');
     });
 
     it('sets up a renderEdge call synchronously', () => {
@@ -267,7 +246,7 @@ describe('GraphView component', () => {
     });
 
     it('renders asynchronously', () => {
-      spyOn(instance, 'syncRenderEdge');
+      jest.spyOn(instance, 'syncRenderEdge');
       const edge = {
         source: 'a',
         target: 'b',
@@ -284,19 +263,23 @@ describe('GraphView component', () => {
   describe('renderEdge method', () => {
     beforeEach(() => {
       instance.entities = {
-        appendChild: jasmine.createSpy(),
+        appendChild: jest.fn(),
       };
-      ReactDOM.render = jasmine.createSpy();
+      ReactDOM.render = jest.fn();
     });
 
     it('appends an edge element into the entities element', () => {
+      output.setProps({
+        edges: [],
+      });
       const element = document.createElement('g');
       const edge = {
         source: 'a',
         target: 'b',
       };
 
-      instance.renderEdge('test', element, edge);
+      // using Date.getTime to make this a unique edge
+      instance.renderEdge(`test-${new Date().getTime()}`, element, edge);
 
       expect(instance.entities.appendChild).toHaveBeenCalled();
     });
@@ -306,7 +289,7 @@ describe('GraphView component', () => {
       const container = document.createElement('g');
 
       container.id = 'test-container';
-      spyOn(document, 'getElementById').and.returnValue(container);
+      jest.spyOn(document, 'getElementById').mockReturnValue(container);
       const edge = {
         source: 'a',
         target: 'b',
@@ -316,6 +299,7 @@ describe('GraphView component', () => {
 
       expect(instance.entities.appendChild).not.toHaveBeenCalled();
       expect(ReactDOM.render).toHaveBeenCalledWith(element, container);
+      document.getElementById.mockRestore();
     });
   });
 
@@ -375,7 +359,7 @@ describe('GraphView component', () => {
 
   describe('renderNodes method', () => {
     beforeEach(() => {
-      spyOn(instance, 'asyncRenderNode');
+      jest.spyOn(instance, 'asyncRenderNode');
       nodes = [{ id: 'a' }, { id: 'b' }];
       output.setProps({
         nodes,
@@ -384,14 +368,14 @@ describe('GraphView component', () => {
 
     it('returns early when there are no entities', () => {
       // asyncRenderNode gets called when new nodes are added. Reset the calls.
-      instance.asyncRenderNode.calls.reset();
+      instance.asyncRenderNode.mockReset();
 
       instance.renderNodes();
       expect(instance.asyncRenderNode).not.toHaveBeenCalled();
     });
 
     it('calls asynchronously renders each node', () => {
-      instance.asyncRenderNode.calls.reset();
+      instance.asyncRenderNode.mockReset();
       instance.entities = [];
       instance.renderNodes();
       expect(instance.asyncRenderNode).toHaveBeenCalledTimes(2);
@@ -446,8 +430,8 @@ describe('GraphView component', () => {
         nodeKey,
         nodes: nodesProp,
       });
-      spyOn(instance, 'renderNode');
-      spyOn(instance, 'renderConnectedEdgesFromNode');
+      jest.spyOn(instance, 'renderNode');
+      jest.spyOn(instance, 'renderConnectedEdgesFromNode');
 
       instance.syncRenderNode(node, 0);
 
@@ -472,7 +456,7 @@ describe('GraphView component', () => {
     });
 
     it('renders asynchronously', () => {
-      spyOn(instance, 'syncRenderNode');
+      jest.spyOn(instance, 'syncRenderNode');
       const node = { id: 'a' };
 
       instance.asyncRenderNode(node);
@@ -487,7 +471,7 @@ describe('GraphView component', () => {
     let node;
 
     beforeEach(() => {
-      spyOn(instance, 'asyncRenderEdge');
+      jest.spyOn(instance, 'asyncRenderEdge');
       node = {
         id: 'a',
         incomingEdges: [{ source: 'b', target: 'a' }],
@@ -515,9 +499,9 @@ describe('GraphView component', () => {
   describe('renderNode method', () => {
     beforeEach(() => {
       instance.entities = {
-        appendChild: jasmine.createSpy(),
+        appendChild: jest.fn(),
       };
-      ReactDOM.render = jasmine.createSpy();
+      ReactDOM.render = jest.fn();
     });
 
     it('appends a node element into the entities element', () => {
@@ -533,11 +517,12 @@ describe('GraphView component', () => {
       const container = document.createElement('g');
 
       container.id = 'test-container';
-      spyOn(document, 'getElementById').and.returnValue(container);
+      jest.spyOn(document, 'getElementById').mockReturnValue(container);
       instance.renderNode('test', element);
 
       expect(instance.entities.appendChild).not.toHaveBeenCalled();
       expect(ReactDOM.render).toHaveBeenCalledWith(element, container);
+      document.getElementById.mockRestore();
     });
   });
 
@@ -572,7 +557,7 @@ describe('GraphView component', () => {
     it('sets up the view and calls renderNodes asynchronously', () => {
       jest.useFakeTimers();
       jest.clearAllTimers();
-      spyOn(instance, 'renderNodes');
+      jest.spyOn(instance, 'renderNodes');
       output.setState({
         viewTransform: 'test',
       });
@@ -598,7 +583,7 @@ describe('GraphView component', () => {
 
   describe('modifyZoom', () => {
     beforeEach(() => {
-      spyOn(instance, 'setZoom');
+      jest.spyOn(instance, 'setZoom');
       instance.viewWrapper = {
         current: document.createElement('div'),
       };
@@ -641,7 +626,7 @@ describe('GraphView component', () => {
 
   describe('handleZoomToFit method', () => {
     beforeEach(() => {
-      spyOn(instance, 'setZoom');
+      jest.spyOn(instance, 'setZoom');
       instance.viewWrapper = {
         current: document.createElement('div'),
       };
@@ -676,9 +661,9 @@ describe('GraphView component', () => {
         },
       });
       instance.entities = document.createElement('g');
-      instance.entities.getBBox = jasmine
-        .createSpy()
-        .and.returnValue({ width: 400, height: 300, x: 5, y: 10 });
+      instance.entities.getBBox = jest
+        .fn()
+        .mockReturnValue({ width: 400, height: 300, x: 5, y: 10 });
     });
 
     it('modifies the zoom to fit the elements', () => {
@@ -698,7 +683,7 @@ describe('GraphView component', () => {
     });
 
     it('does not modify the zoom', () => {
-      instance.entities.getBBox.and.returnValue({
+      instance.entities.getBBox.mockReturnValue({
         width: 0,
         height: 0,
         x: 5,
@@ -709,7 +694,7 @@ describe('GraphView component', () => {
     });
 
     it('uses the maxZoom when k is greater than max', () => {
-      instance.entities.getBBox.and.returnValue({
+      instance.entities.getBBox.mockReturnValue({
         width: 5,
         height: 5,
         x: 5,
@@ -720,7 +705,7 @@ describe('GraphView component', () => {
     });
 
     it('uses the minZoom when k is less than min', () => {
-      instance.entities.getBBox.and.returnValue({
+      instance.entities.getBBox.mockReturnValue({
         width: 10000,
         height: 10000,
         x: 5,
@@ -738,9 +723,9 @@ describe('GraphView component', () => {
 
   describe('handleZoomEnd method', () => {
     beforeEach(() => {
-      spyOn(GraphUtils, 'removeElementFromDom');
-      spyOn(instance, 'canSwap').and.returnValue(false);
-      spyOn(instance, 'syncRenderEdge');
+      jest.spyOn(GraphUtils, 'removeElementFromDom');
+      jest.spyOn(instance, 'canSwap').mockReturnValue(false);
+      jest.spyOn(instance, 'syncRenderEdge');
       output.setProps({
         edges: [{ source: 'a', target: 'b' }],
         nodes: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
@@ -761,7 +746,7 @@ describe('GraphView component', () => {
     });
 
     it('drags an edge', () => {
-      instance.canSwap.and.returnValue(true);
+      instance.canSwap.mockReturnValue(true);
       const draggedEdge = {
         source: 'a',
         target: 'b',
@@ -781,7 +766,7 @@ describe('GraphView component', () => {
     });
 
     it('handles swapping the edge to a different node', () => {
-      instance.canSwap.and.returnValue(true);
+      instance.canSwap.mockReturnValue(true);
       const draggedEdge = {
         source: 'a',
         target: 'b',
@@ -801,17 +786,24 @@ describe('GraphView component', () => {
   });
 
   describe('handleZoom method', () => {
+    let event;
+
     beforeEach(() => {
-      spyOn(instance, 'dragEdge');
-      spyOn(instance, 'renderGraphControls');
-      d3.event = {
+      jest.spyOn(instance, 'dragEdge');
+      jest.spyOn(instance, 'renderGraphControls');
+      event = {
         transform: 'test',
       };
       instance.view = document.createElement('g');
+      instance.viewWrapper = {
+        current: {
+          ownerDocument: document,
+        },
+      };
     });
 
     it('handles the zoom event when a node is not hovered nor an edge is being dragged', () => {
-      instance.handleZoom();
+      instance.handleZoom(event);
       expect(instance.renderGraphControls).toHaveBeenCalled();
       expect(instance.dragEdge).not.toHaveBeenCalled();
     });
@@ -820,7 +812,7 @@ describe('GraphView component', () => {
       output.setState({
         viewTransform: 'test',
       });
-      instance.handleZoom();
+      instance.handleZoom(event);
       expect(instance.renderGraphControls).not.toHaveBeenCalled();
       expect(instance.dragEdge).not.toHaveBeenCalled();
     });
@@ -829,7 +821,7 @@ describe('GraphView component', () => {
       output.setState({
         draggingEdge: true,
       });
-      instance.handleZoom();
+      instance.handleZoom(event);
       expect(instance.renderGraphControls).not.toHaveBeenCalled();
       expect(instance.dragEdge).toHaveBeenCalled();
     });
@@ -838,7 +830,7 @@ describe('GraphView component', () => {
       output.setState({
         hoveredNode: {},
       });
-      instance.handleZoom();
+      instance.handleZoom(event);
       expect(instance.renderGraphControls).toHaveBeenCalled();
       expect(instance.dragEdge).not.toHaveBeenCalled();
     });
@@ -846,17 +838,21 @@ describe('GraphView component', () => {
 
   describe('dragEdge method', () => {
     let draggedEdge;
+    let mouse;
 
     beforeEach(() => {
       draggedEdge = {
         source: 'a',
         target: 'b',
       };
-      spyOn(instance, 'syncRenderEdge');
+      jest.spyOn(instance, 'syncRenderEdge');
       instance.selectedView = d3.select(document.createElement('g'));
-      d3.mouse = jasmine.createSpy().and.returnValue([5, 15]);
+      mouse = jest.fn().mockReturnValue([5, 15]);
       output.setProps({
-        nodes: [{ id: 'a', x: 5, y: 10 }, { id: 'b', x: 10, y: 20 }],
+        nodes: [
+          { id: 'a', x: 5, y: 10 },
+          { id: 'b', x: 10, y: 20 },
+        ],
       });
       output.setState({
         draggedEdge,
@@ -867,12 +863,12 @@ describe('GraphView component', () => {
       output.setState({
         draggedEdge: null,
       });
-      instance.dragEdge();
+      instance.dragEdge(undefined, mouse);
       expect(instance.syncRenderEdge).not.toHaveBeenCalled();
     });
 
     it('drags the edge', () => {
-      instance.dragEdge();
+      instance.dragEdge(undefined, mouse);
       expect(instance.syncRenderEdge).toHaveBeenCalledWith({
         source: draggedEdge.source,
         targetPosition: { x: 5, y: 15 },
@@ -882,20 +878,21 @@ describe('GraphView component', () => {
 
   describe('handleZoomStart method', () => {
     let edge;
+    let event;
 
     beforeEach(() => {
-      spyOn(instance, 'dragEdge');
-      spyOn(instance, 'isArrowClicked').and.returnValue(true);
-      spyOn(instance, 'removeEdgeElement');
+      instance.dragEdge = jest.fn();
+      jest.spyOn(instance, 'isArrowClicked').mockReturnValue(true);
+      jest.spyOn(instance, 'removeEdgeElement');
       edge = { source: 'a', target: 'b' };
       output.setProps({
         edges: [edge],
       });
-      d3.event = {
+      event = {
         sourceEvent: {
           target: {
             classList: {
-              contains: jasmine.createSpy().and.returnValue(true),
+              contains: jest.fn().mockReturnValue(true),
             },
             id: 'a_b',
           },
@@ -908,39 +905,39 @@ describe('GraphView component', () => {
       output.setProps({
         readOnly: true,
       });
-      instance.handleZoomStart();
+      instance.handleZoomStart(event);
       expect(instance.dragEdge).not.toHaveBeenCalled();
     });
 
     it('does nothing when there is no sourceEvent', () => {
-      d3.event = {
+      event = {
         sourceEvent: null,
       };
-      instance.handleZoomStart();
+      instance.handleZoomStart(event);
       expect(instance.dragEdge).not.toHaveBeenCalled();
     });
 
     it('does nothing when the sourceEvent is not an edge', () => {
-      d3.event.sourceEvent.target.classList.contains.and.returnValue(false);
-      instance.handleZoomStart();
+      event.sourceEvent.target.classList.contains.mockReturnValue(false);
+      instance.handleZoomStart(event);
       expect(instance.dragEdge).not.toHaveBeenCalled();
     });
 
     it("does nothing if the arrow wasn't clicked", () => {
-      instance.isArrowClicked.and.returnValue(false);
-      instance.handleZoomStart();
+      instance.isArrowClicked.mockReturnValue(false);
+      instance.handleZoomStart(event);
       expect(instance.dragEdge).not.toHaveBeenCalled();
     });
 
     it('does nothing if there is no edge', () => {
-      d3.event.sourceEvent.target.id = 'fake';
-      instance.handleZoomStart();
+      event.sourceEvent.target.id = 'fake';
+      instance.handleZoomStart(event);
       expect(instance.dragEdge).not.toHaveBeenCalled();
     });
 
     it('drags the edge', () => {
-      d3.event.sourceEvent.buttons = 2;
-      instance.handleZoomStart();
+      event.sourceEvent.buttons = 2;
+      instance.handleZoomStart(event);
       expect(output.state().draggedEdge).toEqual(edge);
       expect(instance.dragEdge).toHaveBeenCalled();
     });
@@ -949,11 +946,11 @@ describe('GraphView component', () => {
   describe('panToEntity method', () => {
     const entity = document.createElement('g');
 
-    entity.getBBox = jasmine
-      .createSpy()
-      .and.returnValue({ width: 400, height: 300, x: 5, y: 10 });
+    entity.getBBox = jest
+      .fn()
+      .mockReturnValue({ width: 400, height: 300, x: 5, y: 10 });
     beforeEach(() => {
-      spyOn(instance, 'setZoom');
+      jest.spyOn(instance, 'setZoom');
       instance.viewWrapper = {
         current: document.createElement('div'),
       };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-digraph",
   "description": "directed graph react component",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "keywords": [
     "uber-library",
     "babel",


### PR DESCRIPTION
Tests seemed to have become broken, possibly due to a Jest upgrade. Jest had made mocking out or redefining d3 functions impossible. This required us to pass the d3.event variable to the functions in a different way and rewrite some tests to work with the new method.

To standardize vscode's configuration, I've added the vscode settings file with various options predefined. This method works well with Flow and eslint.

