### PR TITLE
typings: initialBBox set to optional to match docs

### DIFF
--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -86,5 +86,5 @@ export type IGraphViewProps = {
   renderNodeText?: (data: any, id: string | number, isSelected: boolean) => any,
   rotateEdgeHandle?: boolean,
   centerNodeOnMove?: boolean,
-  initialBBox: IBBox,
+  initialBBox?: IBBox,
 };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -160,7 +160,7 @@ declare module 'react-digraph' {
     ) => any;
     rotateEdgeHandle?: boolean;
     centerNodeOnMove?: boolean;
-    initialBBox: IBBox;
+    initialBBox?: IBBox;
   };
 
   export type IGraphInput = {


### PR DESCRIPTION
Using this project with Typescript and not sending in initialBBox as a prop to GraphView gives me a warning about it being required, but the README say it's not required and the code does a check before using it so I think it's safe to mark this as optional in the typings file.