### PR TITLE
change call to canCreateEdge with nodeId to node.

### DIFF
--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -713,7 +713,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       this.renderConnectedEdgesFromNode(nodeMapNode, true);
       this.asyncRenderNode(node);
     } else if (
-      (canCreateEdge && canCreateEdge(nodeId)) ||
+      (canCreateEdge && canCreateEdge(node)) ||
       this.state.draggingEdge
     ) {
       // render new edge


### PR DESCRIPTION
All other calls to canCreateEdge pass nodes and the docs describe the parameters as (startNode?, endNode?) not nodeId. Fixes #164 