### PR TITLE
chore: update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A React component which makes it easy to create a directed graph editor without 
 
 ## Important v5.0.0 Information
 Version 5.0.0 is a breaking change to some of the API interfaces. Many of the component attributes are the same, and the data format is the same, but there
-have been some necessary changes to improve the API, make the component faster, and add new features. Many changes will be listed below in the deprecation notes section. If you notice a problem, please use the ^4.0.0 versions of the package and refer to the legacy documentation in the `v4.x.x` git branch.
+have been some necessary changes to improve the API, make the component faster, and add new features. Many changes will be listed below in the deprecation notes section. If you notice a problem, please use the `^4.0.0` versions of the package and refer to the legacy documentation in the `v4.x.x` git branch.
 
 ## Installation
 
@@ -22,11 +22,13 @@ npm install --save react react-dom
 ## Usage
 
 
-The default export is a component called 'GraphView'; it provides a multitude of hooks for various graph editing operations and a set of controls for zooming. Typically, it should be wrapped in a higher order component that supplies various callbacks (onCreateNode, onCreateEdge etc...).
+The default export is a component called `GraphView`; it provides a multitude of hooks for various graph editing operations and a set of controls for zooming. Typically, it should be wrapped in a higher order component that supplies various callbacks (`onCreateNode`, `onCreateEdge` etc...).
 
-All nodes and edges can have a type attribute set - nodes also support a subtype attribute. These can be passed to GraphView via the nodeTypes, nodeSubtypes, and edgeTypes props. GraphView will look up the corresponding SVG elements for the node's type/subtype and the edge's type and draw it accordingly.
+`GraphView` expects several properties to exist on your nodes and edges. If these types conflict with existing properties on your data, you must transform your data to re-key these properties under different names and to add the expected properties. All nodes and edges can have a `type` attribute set - nodes also support a `subtype` attribute. For a full description of node and edge properties, see the sections for `INode` and `IEdge` below.
 
-It is often convenient to combine these types into a configuration object that can be referred to elsewhere in the application and used to associate events fired from nodes/edges in the graphView with other actions in the application. Here is an abbreviated example:
+Configuration for nodes and edges can be passed to `GraphView` via the `nodeTypes`, `nodeSubtypes`, and `edgeTypes` props. Custom SVG elements can be defined here for the node's type/subtype and the edge's type.
+
+It is often convenient to combine these types into a configuration object that can be referred to elsewhere in the application and used to associate events fired from nodes/edges in the `GraphView` with other actions in the application. Here is an abbreviated example:
 
 ```jsx
 import {
@@ -194,55 +196,55 @@ All props are detailed below.
 
 ## Props
 
-| Prop                | Type                    | Required  | Notes                                                     |
-| --------------------|:-----------------------:| :--------:| :--------------------------------------------------------:|
-| nodeKey             | string                  | true      | Key for D3 to update nodes(typ. UUID).                    |
-| nodes               | array                   | true      | Array of graph nodes.                                     |
-| edges               | array                   | true      | Array of graph edges.                                     |
-| selected            | object                  | true      | The currently selected graph entity.                      |
-| nodeTypes           | object                  | true      | Config object of available node types.                    |
-| nodeSubtypes        | object                  | true      | Config object of available node subtypes.                 |
-| edgeTypes           | object                  | true      | Config object of available edge types.                    |
-| onSelectNode        | func                    | true      | Called when a node is selected.                           |
-| onCreateNode        | func                    | true      | Called when a node is created.                            |
-| onUpdateNode        | func                    | true      | Called when a node is moved.                              |
-| onDeleteNode        | func                    | true      | Called when a node is deleted.                            |
-| onSelectEdge        | func                    | true      | Called when an edge is selected.                          |
-| onCreateEdge        | func                    | true      | Called when an edge is created.                           |
-| onSwapEdge          | func                    | true      | Called when an edge 'target' is swapped.                  |
-| onDeleteEdge        | func                    | true      | Called when an edge is deleted.                           |
-| onBackgroundClick   | func                    | false     | Called when the background is clicked.                    |
-| canDeleteNode       | func                    | false     | Called before a node is deleted.                          |
-| canCreateEdge       | func                    | false     | Called before an edge is created.                         |
-| canDeleteEdge       | func                    | false     | Called before an edge is deleted.                         |
-| afterRenderEdge      | func                    | false     | Called after an edge is rendered.                         |
-| renderNode          | func                    | false     | Called to render node geometry.                           |
-| renderNodeText      | func                    | false     | Called to render the node text                            |
-| renderDefs          | func                    | false     | Called to render svg definitions.                         |
-| renderBackground    | func                    | false     | Called to render svg background.                          |
-| readOnly            | bool                    | false     | Disables all graph editing interactions.                  |
-| maxTitleChars       | number                  | false     | Truncates node title characters.                          |
-| gridSize            | number                  | false     | Overall grid size.                                        |
-| gridSpacing         | number                  | false     | Grid spacing.                                             |
-| gridDotSize         | number                  | false     | Grid dot size.                                            |
-| minZoom             | number                  | false     | Minimum zoom percentage.                                  |
-| maxZoom             | number                  | false     | Maximum zoom percentage.                                  |
-| nodeSize            | number                  | false     | Node bbox size.                                           |
-| edgeHandleSize      | number                  | false     | Edge handle size.                                         |
-| edgeArrowSize       | number                  | false     | Edge arrow size.                                          |
-| zoomDelay           | number                  | false     | Delay before zoom occurs.                                 |
-| zoomDur             | number                  | false     | Duration of zoom transition.                              |
-| showGraphControls   | boolean                 | false     | Whether to show zoom controls.                            |
-| layoutEngineType    | typeof LayoutEngineType | false     | Uses a pre-programmed layout engine, such as 'SnapToGrid' |
-| rotateEdgeHandle    | boolean                 | false     | Whether to rotate edge handle with edge when a node is moved |
-| centerNodeOnMove    | boolean                 | false     | Weather the node should be centered on cursor when moving a node    |
-| initialBBox         | typeof IBBox            | false     | If specified, initial render graph using the given bounding box|
-| graphConfig         | object                  | false     | [dagre](https://github.com/dagrejs/dagre/wiki#configuring-the-layout) graph setting configuration, which will override layout engine graph configuration - only apply to HorizontalTree|
-| nodeSizeOverridesAllowed | boolean            | false     | Flag to toggle `sizeOverride` in `nodes` - only apply to HorizontalTree |
-| nodeLocationOverrides | object                | false     | Nodes location overrides object - only apply to HorizontalTree |
+| Prop                       | Type                       | Required     | Notes                                                                                                                                                                                       |
+| ----------------------     | :------------------------: | :----------: | :----------------------------------------------------------:                                                                                                                                |
+| `nodeKey`                  | `string`                   | `true`       | Key for D3 to update nodes(typ. UUID).                                                                                                                                                      |
+| `nodes`                    | `Array<INode>`             | `true`       | Array of graph nodes.                                                                                                                                                                       |
+| `edges`                    | `Array<IEdge>`             | `true`       | Array of graph edges.                                                                                                                                                                       |
+| `selected`                 | `object`                   | `true`       | The currently selected graph entity.                                                                                                                                                        |
+| `nodeTypes`                | `object`                   | `true`       | Config object of available node types.                                                                                                                                                      |
+| `nodeSubtypes`             | `object`                   | `true`       | Config object of available node subtypes.                                                                                                                                                   |
+| `edgeTypes`                | `object`                   | `true`       | Config object of available edge types.                                                                                                                                                      |
+| `onSelectNode`             | `func`                     | `true`       | Called when a node is selected.                                                                                                                                                             |
+| `onCreateNode`             | `func`                     | `true`       | Called when a node is created.                                                                                                                                                              |
+| `onUpdateNode`             | `func`                     | `true`       | Called when a node is moved.                                                                                                                                                                |
+| `onDeleteNode`             | `func`                     | `true`       | Called when a node is deleted.                                                                                                                                                              |
+| `onSelectEdge`             | `func`                     | `true`       | Called when an edge is selected.                                                                                                                                                            |
+| `onCreateEdge`             | `func`                     | `true`       | Called when an edge is created.                                                                                                                                                             |
+| `onSwapEdge`               | `func`                     | `true`       | Called when an edge `'target'` is swapped.                                                                                                                                                  |
+| `onDeleteEdge`             | `func`                     | `true`       | Called when an edge is deleted.                                                                                                                                                             |
+| `onBackgroundClick`        | `func`                     | `false`      | Called when the background is clicked.                                                                                                                                                      |
+| `canDeleteNode`            | `func`                     | `false`      | Called before a node is deleted.                                                                                                                                                            |
+| `canCreateEdge`            | `func`                     | `false`      | Called before an edge is created.                                                                                                                                                           |
+| `canDeleteEdge`            | `func`                     | `false`      | Called before an edge is deleted.                                                                                                                                                           |
+| `afterRenderEdge`          | `func`                     | `false`      | Called after an edge is rendered.                                                                                                                                                           |
+| `renderNode`               | `func`                     | `false`      | Called to render node geometry.                                                                                                                                                             |
+| `renderNodeText`           | `func`                     | `false`      | Called to render the node text                                                                                                                                                              |
+| `renderDefs`               | `func`                     | `false`      | Called to render SVG definitions.                                                                                                                                                           |
+| `renderBackground`         | `func`                     | `false`      | Called to render SVG background.                                                                                                                                                            |
+| `readOnly`                 | `bool`                     | `false`      | Disables all graph editing interactions.                                                                                                                                                    |
+| `maxTitleChars`            | `number`                   | `false`      | Truncates node title characters.                                                                                                                                                            |
+| `gridSize`                 | `number`                   | `false`      | Overall grid size.                                                                                                                                                                          |
+| `gridSpacing`              | `number`                   | `false`      | Grid spacing.                                                                                                                                                                               |
+| `gridDotSize`              | `number`                   | `false`      | Grid dot size.                                                                                                                                                                              |
+| `minZoom`                  | `number`                   | `false`      | Minimum zoom percentage.                                                                                                                                                                    |
+| `maxZoom`                  | `number`                   | `false`      | Maximum zoom percentage.                                                                                                                                                                    |
+| `nodeSize`                 | `number`                   | `false`      | Node bbox size.                                                                                                                                                                             |
+| `edgeHandleSize`           | `number`                   | `false`      | Edge handle size.                                                                                                                                                                           |
+| `edgeArrowSize`            | `number`                   | `false`      | Edge arrow size.                                                                                                                                                                            |
+| `zoomDelay`                | `number`                   | `false`      | Delay before zoom occurs.                                                                                                                                                                   |
+| `zoomDur`                  | `number`                   | `false`      | Duration of zoom transition.                                                                                                                                                                |
+| `showGraphControls`        | `boolean`                  | `false`      | Whether to show zoom controls.                                                                                                                                                              |
+| `layoutEngineType`         | `typeof LayoutEngineType`  | `false`      | Uses a pre-programmed layout engine, such as `'SnapToGrid'`                                                                                                                                 |
+| `rotateEdgeHandle`         | `boolean`                  | `false`      | Whether to rotate edge handle with edge when a node is moved                                                                                                                                |
+| `centerNodeOnMove`         | `boolean`                  | `false`      | Whether the node should be centered on cursor when moving a node                                                                                                                            |
+| `initialBBox`              | `typeof IBBox`             | `false`      | If specified, initial render graph using the given bounding box                                                                                                                             |
+| `graphConfig`              | `object`                   | `false`      | [dagre](https://github.com/dagrejs/dagre/wiki#configuring-the-layout) graph setting configuration, which will override layout engine graph configuration - only apply to `'HorizontalTree'` |
+| `nodeSizeOverridesAllowed` | `boolean`                  | `false`      | Flag to toggle `sizeOverride` in `nodes` - only apply to `'HorizontalTree'`                                                                                                                 |
+| `nodeLocationOverrides`    | `object`                   | `false`      | Nodes location overrides object - only apply to `'HorizontalTree'`                                                                                                                          |
 
-### onCreateNode
-You have access to d3 mouse event in `onCreateNode` function.
+### `onCreateNode`
+You have access to `d3` mouse event in `onCreateNode` function.
 ```javascript
   onCreateNode = (x, y, mouseEvent) => {
     // we can get the exact mouse position when click happens with this line
@@ -310,26 +312,55 @@ Prop Types:
   nodeLocationOverrides?: {[string]: {x?: number, y?:number}}
 ```
 
+
+### `INode`
+
+| Prop                   | Type                       | Required     | Notes                                             |
+| ---------------------- | :------------------------: | :----------: | :-----------------------------------------------: |
+| `title`                | `string`                   | `true`       | Used in edges and to render the node text.        |
+| `x`                    | `number`                   | `false`      | X coordinate of the node.                         |
+| `y`                    | `number`                   | `false`      | Y coordinate of the node.                         |
+| `type`                 | `string`                   | `false`      | Node type, for displaying a custom SVG shape.     |
+| `subtype`              | `string`                   | `false`      | Node subtype, for displaying a custom SVG shape.  |
+
+
+#### `title`
+
+The `title` attribute is used for the IDs in the SVG nodes in the graph. Because `Element.querySelector()` is used to locate graph entities, please ensure that all titles are properly escaped (for example, with `CSS.escape()`).
+
+### `IEdge`
+
+| Prop                   | Type                       | Required     | Notes                                             |
+| ---------------------- | :------------------------: | :----------: | :-----------------------------------------------: |
+| `source`               | `string`                   | `true`       | The `title` of the parent node.                   |
+| `target`               | `string`                   | `true`       | The `title` of the child node.                    |
+| `type`                 | `string`                   | `false`      | Edge type, for displaying a custom SVG shape.     |
+| `handleText`           | `string`                   | `false`      | Text to render on the edge.                       |
+| `handleTooltipText`    | `string`                   | `false`      | Used to render the SVG `title` element.           |
+| `label_from`           | `string`                   | `false`      | Text to render along the edge with `label_to`.    |
+| `label_to`             | `string`                   | `false`      | Text to render along the edge with `label_from`.  |
+
+
 ## Imperative API
 You can call these methods on the GraphView class using a ref.
 
-| Method            | Type                                                      | Notes                                                                       |
-| ------------------|:---------------------------------------------------------:|  :-------------------------------------------------------------------------:|
-| panToNode         | (id: string, zoom?: boolean) => void                      | Center the node given by `id` within the viewport, optionally zoom in to fit it. |
-| panToEdge         | (source: string, target: string, zoom?: boolean) => void  | Center the edge between `source` and `target` node IDs within the viewport, optionally zoom in to fit it.  |
+| Method             | Type                                                        | Notes                                                                                                     |
+| ------------------ | :---------------------------------------------------------: | :-------------------------------------------------------------------------:                               |
+| `panToNode`        | `(id: string, zoom?: boolean) => void`                      | Center the node given by `id` within the viewport, optionally zoom in to fit it.                          |
+| `panToEdge`        | `(source: string, target: string, zoom?: boolean) => void`  | Center the edge between `source` and `target` node IDs within the viewport, optionally zoom in to fit it. |
 
 ## Deprecation Notes
 
-| Prop                | Type    | Required  | Notes                                     |
-| --------------------|:-------:| :--------:| :----------------------------------------:|
-| emptyType           | string  | true      | 'Default' node type.                      |
-| getViewNode         | func    | true      | Node getter.                              |
-| renderEdge          | func    | false     | Called to render edge geometry.           |
-| enableFocus         | bool    | false     | Adds a 'focus' toggle state to GraphView. |
-| transitionTime      | number  | false     | Fade-in/Fade-out time.                    |
-| primary             | string  | false     | Primary color.                            |
-| light               | string  | false     | Light color.                              |
-| dark                | string  | false     | Dark color.                               |
-| style               | object  | false     | Style prop for wrapper.                   |
-| gridDot             | number  | false     | Grid dot size.                            |
-| graphControls       | boolean | true      | Whether to show zoom controls.            |
+| Prop                 | Type      | Required   | Notes                                      |
+| -------------------- | :-------: | :--------: | :----------------------------------------: |
+| `emptyType`          | `string`  | `true`     | 'Default' node type.                       |
+| `getViewNode`        | `func`    | `true`     | Node getter.                               |
+| `renderEdge`         | `func`    | `false`    | Called to render edge geometry.            |
+| `enableFocus`        | `bool`    | `false`    | Adds a 'focus' toggle state to GraphView.  |
+| `transitionTime`     | `number`  | `false`    | Fade-in/Fade-out time.                     |
+| `primary`            | `string`  | `false`    | Primary color.                             |
+| `light`              | `string`  | `false`    | Light color.                               |
+| `dark`               | `string`  | `false`    | Dark color.                                |
+| `style`              | `object`  | `false`    | Style prop for wrapper.                    |
+| `gridDot`            | `number`  | `false`    | Grid dot size.                             |
+| `graphControls`      | `boolean` | `true`     | Whether to show zoom controls.             |


### PR DESCRIPTION
Adds a props section for `INode` and `IEdge`. Also describes the issue
with CSS-valid string escaping for `INode['title']`.

Also does some cleanup throughout the document (mostly formatting).