### PR TITLE
add HorizontalTree to LayoutEngineType

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -186,7 +186,7 @@ declare module 'react-digraph' {
     static revert(graphInput: IGraphInput): any;
   }
 
-  export type LayoutEngineType = 'None' | 'SnapToGrid' | 'VerticalTree';
+  export type LayoutEngineType = 'None' | 'SnapToGrid' | 'VerticalTree' | 'HorizontalTree';
 
   export const GraphView: React.ComponentClass<IGraphViewProps>;
   export type INodeMapNode = {


### PR DESCRIPTION
## Summary
This repository has [horizontal tree render implementation](https://github.com/uber/react-digraph/blob/fc4bdaecdbbc0000d77335e08bacb404050dfc5f/src/utilities/layout-engine/horizontal-tree.js#L23) and [hirizontal tree type](https://github.com/uber/react-digraph/blob/master/src/utilities/layout-engine/layout-engine-types.js) in js file, but `LayoutEnginType` in index.d.ts dosen't have 'HorizontalTree'.
So, modified `LayoutEngineType` to have 'HorizontalTree' type.
This would be useful for typescript users.