### PR TITLE
resolve #212

### DIFF
--- a/__tests__/components/graph-view.test.js
+++ b/__tests__/components/graph-view.test.js
@@ -231,6 +231,36 @@ describe('GraphView component', () => {
         false
       );
     });
+
+    it('sets up a renderEdge call synchronously when source key = 0', () => {
+      const expectedEdge = {
+        source: 0,
+        target: 'b',
+      };
+
+      instance.syncRenderEdge(expectedEdge);
+      expect(instance.renderEdge).toHaveBeenCalledWith(
+        'edge-0-b',
+        'blah',
+        expectedEdge,
+        false
+      );
+    });
+
+    it('sets up a renderEdge call synchronously when target key = 0', () => {
+      const expectedEdge = {
+        source: 'a',
+        target: 0,
+      };
+
+      instance.syncRenderEdge(expectedEdge);
+      expect(instance.renderEdge).toHaveBeenCalledWith(
+        'edge-a-0',
+        'blah',
+        expectedEdge,
+        false
+      );
+    });
   });
 
   describe('asyncRenderEdge method', () => {
@@ -255,6 +285,34 @@ describe('GraphView component', () => {
       instance.asyncRenderEdge(edge);
 
       expect(instance.edgeTimeouts['edges-a-b']).toBeDefined();
+      expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+      expect(instance.syncRenderEdge).toHaveBeenCalledWith(edge, false);
+    });
+
+    it('renders asynchronously when source key = 0', () => {
+      jest.spyOn(instance, 'syncRenderEdge');
+      const edge = {
+        source: 0,
+        target: 'b',
+      };
+
+      instance.asyncRenderEdge(edge);
+
+      expect(instance.edgeTimeouts['edges-0-b']).toBeDefined();
+      expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+      expect(instance.syncRenderEdge).toHaveBeenCalledWith(edge, false);
+    });
+
+    it('renders asynchronously when target key = 0', () => {
+      jest.spyOn(instance, 'syncRenderEdge');
+      const edge = {
+        source: 'a',
+        target: 0,
+      };
+
+      instance.asyncRenderEdge(edge);
+
+      expect(instance.edgeTimeouts['edges-a-0']).toBeDefined();
       expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
       expect(instance.syncRenderEdge).toHaveBeenCalledWith(edge, false);
     });

--- a/src/components/edge.js
+++ b/src/components/edge.js
@@ -409,7 +409,7 @@ class Edge extends React.Component<IEdgeProps> {
   ) {
     let response = Edge.getDefaultIntersectResponse();
 
-    if (!trg[nodeKey]) {
+    if (trg[nodeKey] == null) {
       return response;
     }
 
@@ -660,7 +660,7 @@ class Edge extends React.Component<IEdgeProps> {
       return null;
     }
 
-    const id = `${data.source || ''}_${data.target}`;
+    const id = `${data.source != null ? data.source : ''}_${data.target}`;
     const className = GraphUtils.classNames('edge', {
       selected: this.props.isSelected,
     });

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -306,7 +306,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   getNodeById(id: string | null, nodesMap: any | null): INodeMapNode | null {
     const nodesMapVar = nodesMap || this.state.nodesMap;
 
-    return nodesMapVar ? nodesMapVar[`key-${id || ''}`] : null;
+    return nodesMapVar ? nodesMapVar[`key-${id != null ? id : ''}`] : null;
   }
 
   getEdgeBySourceTarget(source: string, target: string): IEdge | null {
@@ -405,7 +405,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       GraphUtils.yieldingLoop(edges.length, 50, i => {
         edge = edges[i];
 
-        if (!edge.source || !edge.target) {
+        if (edge.source == null || !edge.target == null) {
           return;
         }
 
@@ -434,8 +434,8 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
       // Check for deletions
       if (
-        !edge.source ||
-        !edge.target ||
+        edge.source == null ||
+        edge.target == null ||
         !edgesMap[`${edge.source}_${edge.target}`]
       ) {
         // remove edge
@@ -484,7 +484,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   deleteEdge(selectedEdge: IEdge) {
     const { edges } = this.state;
 
-    if (!selectedEdge.source || !selectedEdge.target) {
+    if (selectedEdge.source == null || selectedEdge.target == null) {
       return;
     }
 
@@ -495,7 +495,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       );
     });
 
-    if (selectedEdge.source && selectedEdge.target) {
+    if (selectedEdge.source != null && selectedEdge.target != null) {
       this.deleteEdgeBySourceTarget(selectedEdge.source, selectedEdge.target);
     }
 
@@ -505,7 +505,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     });
 
     // remove from UI
-    if (selectedEdge.source && selectedEdge.target) {
+    if (selectedEdge.source != null && selectedEdge.target != null) {
       // remove extra custom containers just in case.
       GraphUtils.removeElementFromDom(
         `edge-${selectedEdge.source}-${selectedEdge.target}-custom-container`
@@ -526,10 +526,14 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       return;
     }
 
-    if (!selected.source && canDeleteNode && canDeleteNode(selected)) {
+    if (selected.source == null && canDeleteNode && canDeleteNode(selected)) {
       // node
       this.deleteNode(selected);
-    } else if (selected.source && canDeleteEdge && canDeleteEdge(selected)) {
+    } else if (
+      selected.source != null &&
+      canDeleteEdge &&
+      canDeleteEdge(selected)
+    ) {
       // edge
       this.deleteEdge(selected);
     }
@@ -590,10 +594,10 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       focused: true,
     };
 
-    if (source && target) {
+    if (source != null && target != null) {
       const edge: IEdge | null = this.getEdgeBySourceTarget(source, target);
 
-      if (!edge) {
+      if (edge == null) {
         return;
       }
 
@@ -871,7 +875,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     const xycoords = d3.mouse(eventTarget);
 
-    if (!edge.target) {
+    if (edge.target == null) {
       return false;
     }
 
@@ -1401,7 +1405,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   };
 
   asyncRenderEdge = (edge: IEdge, nodeMoving: boolean = false) => {
-    if (!edge.source || !edge.target) {
+    if (edge.source == null || edge.target == null) {
       return;
     }
 
@@ -1414,12 +1418,13 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   };
 
   syncRenderEdge(edge: IEdge | any, nodeMoving: boolean = false) {
-    if (!edge.source) {
+    if (edge.source == null) {
       return;
     }
 
     // We have to use the 'custom' id when we're drawing a new node
-    const idVar = edge.target ? `${edge.source}-${edge.target}` : 'custom';
+    const idVar =
+      edge.target != null ? `${edge.source}-${edge.target}` : 'custom';
     const id = `edge-${idVar}`;
     const element = this.getEdgeComponent(edge);
 

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -54,7 +54,7 @@ const sample: IGraph = {
     {
       handleText: '5',
       handleTooltipText: '5',
-      source: 'start1',
+      source: 0,
       target: 'a1',
       type: SPECIAL_EDGE_TYPE,
     },
@@ -110,7 +110,7 @@ const sample: IGraph = {
   ],
   nodes: [
     {
-      id: 'start1',
+      id: 0,
       title: 'Start (0)',
       type: SPECIAL_TYPE,
     },

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -54,7 +54,7 @@ const sample: IGraph = {
     {
       handleText: '5',
       handleTooltipText: '5',
-      source: 0,
+      source: 'start1',
       target: 'a1',
       type: SPECIAL_EDGE_TYPE,
     },
@@ -110,7 +110,7 @@ const sample: IGraph = {
   ],
   nodes: [
     {
-      id: 0,
+      id: 'start1',
       title: 'Start (0)',
       type: SPECIAL_TYPE,
     },

--- a/src/utilities/graph-util.js
+++ b/src/utilities/graph-util.js
@@ -56,11 +56,11 @@ class GraphUtils {
     for (let i = 0; i < arr.length; i++) {
       item = arr[i];
 
-      if (!item.target) {
+      if (item.target == null) {
         continue;
       }
 
-      map[`${item.source || ''}_${item.target}`] = {
+      map[`${item.source != null ? item.source : ''}_${item.target}`] = {
         edge: item,
         originalArrIndex: i,
       };
@@ -77,11 +77,12 @@ class GraphUtils {
     for (let i = 0; i < edges.length; i++) {
       edge = edges[i];
 
-      if (!edge.target) {
+      if (edge.target == null) {
         continue;
       }
 
-      nodeMapSourceNode = nodesMap[`key-${edge.source || ''}`];
+      nodeMapSourceNode =
+        nodesMap[`key-${edge.source != null ? edge.source : ''}`];
       nodeMapTargetNode = nodesMap[`key-${edge.target}`];
 
       // avoid an orphaned edge


### PR DESCRIPTION
Fix #212 

Problem: Node with key=0 has weird behaviour because value check fails. (ex. `!node[nodeKey]`)
Solution: All occurrence of value check on node key, edge source, and edge target are replaced with an explicit comparison with null. (a.k.a. `node[nodeKey] == null`)

The example code is also changed to demonstrate the case using the node with key=0.