### PR TITLE
Fixed edge rendering for Firefox and cleaned up code.

### DIFF
--- a/src/components/arrowhead-marker.js
+++ b/src/components/arrowhead-marker.js
@@ -47,6 +47,8 @@ class ArrowheadMarker extends React.Component<IArrowheadMarkerProps> {
           className="arrow"
           d={`M0,-${edgeArrowSize / 2}L${edgeArrowSize},0L0,${edgeArrowSize /
             2}`}
+          width={`${edgeArrowSize}`}
+          height={`${edgeArrowSize}`}
         />
       </marker>
     );

--- a/src/components/edge-handle-text.js
+++ b/src/components/edge-handle-text.js
@@ -1,0 +1,24 @@
+// @flow
+
+import React from 'react';
+
+type EdgeHandleTextProps = {
+  handleText: string,
+  edgeHandleTranslation: string,
+};
+
+export function EdgeHandleText({
+  handleText,
+  edgeHandleTranslation,
+}: EdgeHandleTextProps) {
+  return (
+    <text
+      className="edge-text"
+      textAnchor="middle"
+      alignmentBaseline="central"
+      transform={`${edgeHandleTranslation}`}
+    >
+      {handleText}
+    </text>
+  );
+}

--- a/src/components/edge-label-text.js
+++ b/src/components/edge-label-text.js
@@ -1,0 +1,32 @@
+// @flow
+import React from 'react';
+import { type IEdge } from './edge';
+
+type EdgeLabelTextProps = {
+  data: IEdge,
+  edgeHandleRotation: [string, boolean],
+  edgeHandleTranslation: string,
+};
+
+export function EdgeLabelText({
+  data,
+  edgeHandleRotation,
+  edgeHandleTranslation,
+}: EdgeLabelTextProps) {
+  const [rotation, isRotated] = edgeHandleRotation;
+  const title = isRotated
+    ? `${data.label_to || ''}${data.label_from ? ` ↔ ${data.label_from}` : ''}`
+    : `${data.label_from || ''}${data.label_to ? ` ↔ ${data.label_to}` : ''}`;
+
+  return (
+    <text
+      className="edge-text"
+      textAnchor="middle"
+      alignmentBaseline="central"
+      style={{ fontSize: '11px', stroke: 'none', fill: 'black' }}
+      transform={`${edgeHandleTranslation} ${rotation} translate(0,-5)`}
+    >
+      {title}
+    </text>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,9 @@ export type IEdgeType = IEdge;
 export { default as GraphUtils } from './utilities/graph-util';
 export { default as Node } from './components/node';
 export type INodeType = INode;
-export { default as BwdlTransformer } from './utilities/transformers/bwdl-transformer';
+export {
+  default as BwdlTransformer,
+} from './utilities/transformers/bwdl-transformer';
 export { GV as GraphView };
 export type LayoutEngineType = LayoutEngineConfigTypes;
 export default GV;


### PR DESCRIPTION
Fixed some of the edge rendering for Firefox. Refactored the Edge code to remove the renderXYZ functions, since those should have been components.

One thing I couldn't fix was the edge handle text rendering at the top of the handles, rather than in the middle. For some reason Firefox is putting the text in the wrong location.

Before:
![Screenshot_2020-05-10_01-42-39](https://user-images.githubusercontent.com/161761/81494728-e208d700-925f-11ea-9dbf-463f60233209.png)

After:
![Screenshot_2020-05-10_01-41-15](https://user-images.githubusercontent.com/161761/81494729-e2a16d80-925f-11ea-9ee3-00a6a076602f.png)
