### PR TITLE
typings: add arg "event" to onSelectNode

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -133,7 +133,7 @@ declare module 'react-digraph' {
     onDeleteNode: (selected: any, nodeId: string, nodes: any[]) => void;
     onPasteSelected?: () => void;
     onSelectEdge: (selectedEdge: IEdge) => void;
-    onSelectNode: (node: INode | null) => void;
+    onSelectNode: (node: INode | null, event: any) => void;
     onSwapEdge: (sourceNode: INode, targetNode: INode, edge: IEdge) => void;
     onUndo?: () => void;
     onUpdateNode: (node: INode) => void;


### PR DESCRIPTION
## Summary
#112 and #130 make onSelectNode function put an argument "event" but in typings/index.d.ts it have not modified yet.
So  I add arg "event" to onSelectNode props of IGraphViewProps in index.d.ts.
