### PR TITLE
Paste selected node at current mouse position

### DIFF
--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -662,7 +662,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       ) {
         const xycoords = d3.mouse(d3.event.target);
 
-        onPasteSelected(xycoords[0], xycoords[1], previousSelection);
+        onPasteSelected(previousSelection, xycoords);
 
         return;
       }

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -624,6 +624,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       onSelectNode,
       readOnly,
       onCreateNode,
+      onPasteSelected,
     } = this.props;
 
     if (this.isPartOfEdge(d3.event.target)) {
@@ -651,6 +652,20 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
       const previousSelection =
         (this.state.selectedNodeObj && this.state.selectedNodeObj.node) || null;
+
+      // Clicking with ctrl will paste
+      if (
+        onPasteSelected &&
+        !readOnly &&
+        d3.event.ctrlKey &&
+        previousSelection
+      ) {
+        const xycoords = d3.mouse(d3.event.target);
+
+        onPasteSelected(xycoords[0], xycoords[1], previousSelection);
+
+        return;
+      }
 
       // de-select the current selection
       this.setState({

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -456,8 +456,11 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
       return;
     }
 
+    const x = this.state.selected.x + 10;
+    const y = this.state.selected.y + 10;
+
     this.setState({
-      copiedNode: { ...this.state.selected },
+      copiedNode: { ...this.state.selected, x, y },
     });
   };
 

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -456,23 +456,15 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
       return;
     }
 
-    const x = this.state.selected.x + 10;
-    const y = this.state.selected.y + 10;
-
     this.setState({
-      copiedNode: { ...this.state.selected, x, y },
+      copiedNode: { ...this.state.selected },
     });
   };
 
-  onPasteSelected = () => {
-    if (!this.state.copiedNode) {
-      console.warn(
-        'No node is currently in the copy queue. Try selecting a node and copying it with Ctrl/Command-C'
-      );
-    }
-
+  // Pastes the copied node to mouse position
+  onPasteSelected = (x: Number, y: Number, node: INode) => {
     const graph = this.state.graph;
-    const newNode = { ...this.state.copiedNode, id: Date.now() };
+    const newNode = { ...node, x, y, id: Date.now() };
 
     graph.nodes = [...graph.nodes, newNode];
     this.forceUpdate();

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -464,10 +464,16 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
     });
   };
 
-  // Pastes the copied node to mouse position
-  onPasteSelected = (x: Number, y: Number, node: INode) => {
+  // Pastes the selected node to mouse position
+  onPasteSelected = (node: INode, mousePosition: [number, number]) => {
     const graph = this.state.graph;
-    const newNode = { ...node, x, y, id: Date.now() };
+
+    const newNode = {
+      ...node,
+      id: Date.now(),
+      x: mousePosition[0],
+      y: mousePosition[1],
+    };
 
     graph.nodes = [...graph.nodes, newNode];
     this.forceUpdate();


### PR DESCRIPTION
Hello,

Upon looking at the [example](https://github.com/uber/react-digraph/blob/9701747628f7f1ee521c1b9e7c830b2aa28a3bb9/src/examples/graph.js#L467) code for copy/pasting a node, I realized that it will paste relative to the selected node instead of the position of the mouse.

Although it is not much of an inconvenience, I thought it would be more intuitive to paste on the current position of the mouse. My goal was to pass the coordinates of the mouse when pasting (like `onPasteSelected(x: Number, y: Number)`). However, I had a lot of trouble trying to deviate as little as possible from the original code to achieve my goal. As a result, I had to pass in the node data alongside with the coordinates: `onPasteSelected(x: Number, y: Number, node: INode)` and probably mess up the code.

I do not expect this pull request to be successful, but I wanted to ask if such feature could be implemented. Based on [this](https://github.com/uber/react-digraph/issues/178) issue, I am guessing that a whole new method of copy/pasting is currently being implemented.

Thank you for this awesome component!