### PR TITLE
Disable backspace shortcut key

### DIFF
--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -28,6 +28,7 @@ export type IBBox = {
 
 export type IGraphViewProps = {
   backgroundFillId?: string,
+  disableBackspace?: boolean,
   edges: any[],
   edgeArrowSize?: number,
   edgeHandleSize?: number,

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -576,7 +576,13 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   };
 
   handleWrapperKeydown: KeyboardEventListener = d => {
-    const { selected, onUndo, onCopySelected, onPasteSelected } = this.props;
+    const {
+      selected,
+      disableBackspace,
+      onUndo,
+      onCopySelected,
+      onPasteSelected,
+    } = this.props;
     const { focused, selectedNodeObj } = this.state;
 
     // Conditionally ignore keypress events on the window
@@ -586,8 +592,13 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     switch (d.key) {
       case 'Delete':
-      case 'Backspace':
         if (selectedNodeObj) {
+          this.handleDelete(selectedNodeObj.node || selected);
+        }
+
+        break;
+      case 'Backspace':
+        if (selectedNodeObj && !disableBackspace) {
           this.handleDelete(selectedNodeObj.node || selected);
         }
 


### PR DESCRIPTION
As stated in the issue: https://github.com/uber/react-digraph/issues/10, I thought it would be nice to have an option to disable the `Backspace` key from also removing the node as the `Del` key already executes the same process.

I need to disable the `Backspace` key because the selected node would get deleted when I try to edit the selected node through an input component on the same level.

Is there a way around this with the existing features? It feels like there should be another way to solve this problem. However, I do not prefer using the ref as mentioned in the issue.

Thank you for the consistent updates!