### PR TITLE
contextmenu event xycoords always to background

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Prop Types:
   onDeleteNode: (selected: any, nodeId: string, nodes: any[]) => void;
   onSelectNode: (node: INode | null) => void;
   onCreateNode: (x: number, y: number, event: object) => void;
+  onContextMenu: (x: number, y: number, event: object) => void;
   onCreateEdge: (sourceNode: INode, targetNode: INode) => void;
   onDeleteEdge: (selectedEdge: IEdge, edges: IEdge[]) => void;
   onUpdateNode: (node: INode) => void;

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -734,7 +734,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     const { onContextMenu } = this.props;
 
     if (typeof onContextMenu === 'function') {
-      const xycoords = d3.mouse(d3.event.target);
+      const xycoords = d3.mouse(this.view);
 
       onContextMenu(xycoords[0], xycoords[1], d3.event);
     }


### PR DESCRIPTION
In our app, `d3.mouse(d3.event.target)` is referring to `<svg class="graph">` instead of `<rect class="background">` in most of the cases
set contextmenu event xycoords always to background