### PR TITLE
Fixed edge bug where edges were created after leaving a node

### DIFF
--- a/__tests__/components/node.test.js
+++ b/__tests__/components/node.test.js
@@ -112,7 +112,7 @@ describe('Node component', () => {
         node.props().onMouseOver(event);
       });
 
-      expect(onNodeMouseEnter).toHaveBeenCalledWith(event, nodeData, true);
+      expect(onNodeMouseEnter).toHaveBeenCalledWith(event, nodeData);
     });
 
     it('calls handleMouseOut', () => {

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -873,7 +873,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
   handleNodeUpdate = (position: any, nodeId: string, shiftKey: boolean) => {
     const { onUpdateNode, readOnly } = this.props;
-    const { draggingEdge } = this.state;
+    const { draggingEdge, hoveredNode, edgeEndNode } = this.state;
 
     if (readOnly) {
       return;
@@ -881,13 +881,12 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     // Detect if edge is being drawn and link to hovered node
     // This will handle a new edge
-    if (shiftKey) {
+    if (shiftKey && hoveredNode && edgeEndNode) {
       this.createNewEdge();
     } else {
       if (draggingEdge) {
         this.removeCustomEdge();
         this.endDragEdge();
-        this.createNewEdge();
       }
 
       const nodeMap = this.getNodeById(nodeId);
@@ -917,11 +916,11 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     });
   };
 
-  handleNodeMouseEnter = (event: any, data: any, hovered: boolean) => {
-    const { hoveredNode, draggingEdge } = this.state;
+  handleNodeMouseEnter = (event: any, data: any) => {
+    const { draggingEdge, hoveredNodeData } = this.state;
 
     // hovered is false when creating edges
-    if (hoveredNode && draggingEdge) {
+    if (hoveredNodeData && data !== hoveredNodeData && draggingEdge) {
       this.setState({
         edgeEndNode: data,
       });
@@ -934,25 +933,9 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
   };
 
   handleNodeMouseLeave = (event: any, data: any) => {
-    if (
-      !!GraphUtils.findParent(d3.event?.toElement, 'g.node', 'svg.graph') ||
-      !!GraphUtils.findParent(event?.relatedTarget, 'g.node', 'svg.graph') ||
-      !!GraphUtils.findParent(d3.event?.target, 'g.node', 'svg.graph') ||
-      !!GraphUtils.findParent(event?.target, 'g.node', 'svg.graph') ||
-      d3.event?.buttons === 1 ||
-      (event && event.buttons === 1)
-    ) {
-      // still within a node
-      return;
-    }
-
-    if (event?.relatedTarget) {
-      if (event.relatedTarget.matches('.edge-overlay-path')) {
-        return;
-      }
-
-      this.setState({ hoveredNode: false, edgeEndNode: null });
-    }
+    this.setState({
+      edgeEndNode: null,
+    });
   };
 
   handleNodeSelected = (

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -58,7 +58,7 @@ type INodeProps = {
   nodeSize?: number,
   nodeWidth?: number,
   nodeHeight?: number,
-  onNodeMouseEnter: (event: any, data: any, hovered: boolean) => void,
+  onNodeMouseEnter: (event: any, data: any) => void,
   onNodeMouseLeave: (event: any, data: any) => void,
   onNodeMove: (point: IPoint, id: string, shiftKey: boolean) => void,
   onNodeSelected: (
@@ -118,11 +118,10 @@ function Node({
 
   const handleMouseOver = useCallback(
     (event: any) => {
-      // Detect if mouse is already down and do nothing.
       const isHovered = true;
 
       setHovered(isHovered);
-      onNodeMouseEnter(event, data, isHovered);
+      onNodeMouseEnter(event, data);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [onNodeMouseEnter, data]


### PR DESCRIPTION
Previously, once a node was hovered it was considered as the endEdgeNode no matter where you dropped the edge. This meant that if you passed the node and dropped the edge in the graph blank area then it would still connect to the previously hovered node.

With recent updates to the node.js file, this code has been simplified. 

It's possible in the future to consider rewriting graph-view.js for greater simplicity but we won't cover that in this diff.