### PR TITLE
Add edge type to edge classnames

### DIFF
--- a/__tests__/components/edge.test.js
+++ b/__tests__/components/edge.test.js
@@ -64,7 +64,7 @@ describe('Edge component', () => {
         .find('g')
         .first();
 
-      expect(g.props().className).toEqual('edge');
+      expect(g.props().className).toEqual('edge fake');
 
       const path = output.find('path').first();
 

--- a/src/components/edge.js
+++ b/src/components/edge.js
@@ -110,7 +110,7 @@ function Edge({
   }
 
   const id = `${data.source != null ? data.source : ''}_${data.target}`;
-  const className = GraphUtils.classNames('edge', {
+  const className = GraphUtils.classNames('edge', data.type, {
     selected: isSelected,
   });
   const isBeingDraggedStyle = {


### PR DESCRIPTION
Similar to how a node's type is included in the list of its dom class names [0], include an edge's type in its class names.

[0] https://github.com/uber/react-digraph/blob/2442a94d100280b68966b91183515575611e7b51/__tests__/components/node.test.js#L82

Usecase: We show edges in different colors according to their type. An alternative may be to include a `color` property or similar in the objects passed to `edgeTypes` prop.

Test Plan: `yarn test`