### PR TITLE
Make removeElementFromDom safe against invalid selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Prop Types:
 
 #### `title`
 
-The `title` attribute is used for the IDs in the SVG nodes in the graph. Because `Element.querySelector()` is used to locate graph entities, please ensure that all titles are properly escaped (for example, with `CSS.escape()`).
+The `title` attribute is used for the IDs in the SVG nodes in the graph.
 
 ### `IEdge`
 

--- a/src/utilities/graph-util.js
+++ b/src/utilities/graph-util.js
@@ -96,7 +96,7 @@ class GraphUtils {
   }
 
   static removeElementFromDom(id: string, searchElement?: any = document) {
-    const container = searchElement.querySelector(`#${id}`);
+    const container = searchElement.querySelector(`[id='${id}']`);
 
     if (container && container.parentNode) {
       container.parentNode.removeChild(container);


### PR DESCRIPTION
Unlike most other uses of `querySelector`, the use in `removeElementFromDom` created an id selector in the style of `#myid` rather than `[id='myid']`. This meant that characters that created invalid CSS selectors were not safe. Instead, use the same attribute selector found elsewhere in react-digraph to locate the element.

Given the number of these throughout the codebase, it may be useful to create a utility along the lines of `findElementById(ancestor: Element, id: string): Element`.

This also removes the note in the README about using `CSS.escape` to pre-escape these kinds of labels, as pre-escaped labels would actually store the escaped strings as ids, and any selectors using escaped ids look for their unescaped equivalents.

Test Plan: Create a graph with node labels using `:` and update it with an empty set of nodes. Verify that no invalid selector errors are thrown.