### PR TITLE
Removed z-index since it can conflict with website settings

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -124,7 +124,6 @@ $background-color: #f9f9f9;
     position: absolute;
     bottom: 30px;
     left: 15px;
-    z-index: 100;
     display: grid;
     grid-template-columns: auto auto;
     grid-gap: 15px;


### PR DESCRIPTION
This z-index can conflict with website elements, such as modals. We should remove it and allow website owners to override the elements with their own CSS instead, if they need to.

They would add a z-index to `.view-wrapper .graph-controls`.