### PR TITLE
Fix: TypeError: Cannot read property 'x' of undefined

### DIFF
--- a/src/helpers/edge-helpers.js
+++ b/src/helpers/edge-helpers.js
@@ -236,9 +236,9 @@ export function getPathDescription(
   return getLine(linePoints);
 }
 
-export function getTheta(pt1?: ITargetPosition | null, pt2: ITargetPosition) {
-  const xComp = (pt2.x || 0) - (pt1?.x || 0);
-  const yComp = (pt2.y || 0) - (pt1?.y || 0);
+export function getTheta(pt1?: ITargetPosition | null, pt2?: ITargetPosition) {
+  const xComp = (pt2?.x || 0) - (pt1?.x || 0);
+  const yComp = (pt2?.y || 0) - (pt1?.y || 0);
   const theta = Math.atan2(yComp, xComp);
 
   return theta;


### PR DESCRIPTION
Fixes in client project:

```
TypeError: Cannot read property 'x' of undefined

      at getTheta (node_modules/react-digraph/dist/webpack:/ReactDigraph/helpers/edge-helpers.js:240:22)
      at getEdgeHandleRotation (node_modules/react-digraph/dist/webpack:/ReactDigraph/helpers/edge-helpers.js:277:16)
      at su (node_modules/react-digraph/dist/webpack:/ReactDigraph/components/edge.js:84:30)
```