### PR TITLE
Fix for Cannot read property 'x' of undefined in getPathIntersect

### DIFF
--- a/src/helpers/intersect-helpers.js
+++ b/src/helpers/intersect-helpers.js
@@ -105,8 +105,8 @@ export function getRotatedRectIntersect(
 
 export function getPathIntersect(
   defSvgPathElement: any,
-  src: any,
-  trg: any,
+  src?: any,
+  trg?: any,
   includesArrow?: boolean = true,
   viewWrapperElem: HTMLDivElement
 ) {
@@ -121,10 +121,10 @@ export function getPathIntersect(
     clientRect.width || defSvgPathElement.parentElement.getAttribute('width');
   const h =
     clientRect.height || defSvgPathElement.parentElement.getAttribute('height');
-  const trgX = trg.x || 0;
-  const trgY = trg.y || 0;
-  const srcX = src.x || 0;
-  const srcY = src.y || 0;
+  const trgX = trg?.x || 0;
+  const trgY = trg?.y || 0;
+  const srcX = src?.x || 0;
+  const srcY = src?.y || 0;
 
   // calculate the positions of each corner relative to the trg position
   const top = trgY - h / 2;


### PR DESCRIPTION
Fix for:

```
TypeError: Cannot read property 'x' of undefined

      at getPathIntersect (node_modules/react-digraph/dist/webpack:/ReactDigraph/helpers/intersect-helpers.js:126:20)
      at calculateOffset (node_modules/react-digraph/dist/webpack:/ReactDigraph/helpers/edge-helpers.js:165:10)
      at getPathDescription (node_modules/react-digraph/dist/webpack:/ReactDigraph/helpers/edge-helpers.js:208:18)
```