### PR TITLE
#178 - Added multiselect ability using the allowMultiselect property

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,21 +201,28 @@ All props are detailed below.
 | `nodeKey`                  | `string`                   | `true`       | Key for D3 to update nodes(typ. UUID).                                                                                                                                                      |
 | `nodes`                    | `Array<INode>`             | `true`       | Array of graph nodes.                                                                                                                                                                       |
 | `edges`                    | `Array<IEdge>`             | `true`       | Array of graph edges.                                                                                                                                                                       |
-| `selected`                 | `object`                   | `true`       | The currently selected graph entity.                                                                                                                                                        |
+| `allowMultiselect`         | `boolean`                  | `false`      | Use Ctrl-Shift-LeftMouse to draw a multiple selection box |
+| `selected`                 | `object`                   | `true`       | The currently selected graph entity. |
+| `selectedNodes`                 | `Array<INode>`                   | `false`       | If allowMultiselect is true, this should be the currently selected array of nodes. |
+| `selectedEdges`                 | `Array<IEdge>`                   | `true`       | If allowMultiselect is true, this should be the currently selected array of edges. |
 | `nodeTypes`                | `object`                   | `true`       | Config object of available node types.                                                                                                                                                      |
 | `nodeSubtypes`             | `object`                   | `true`       | Config object of available node subtypes.                                                                                                                                                   |
 | `edgeTypes`                | `object`                   | `true`       | Config object of available edge types.                                                                                                                                                      |
-| `onSelectNode`             | `func`                     | `true`       | Called when a node is selected.                                                                                                                                                             |
+| `onSelect`             | `func`                     | `false`       | Called when nodes are selected when `allowMultiselect` is true. Is passed an object with nodes and edges included. |
+| `onSelectNode`             | `func`                     | `false`       | Called when a node is selected. |
 | `onCreateNode`             | `func`                     | `true`       | Called when a node is created.                                                                                                                                                              |
 | `onContextMenu`            | `func`                     | `true`       | Called when contextmenu event triggered.                                                                                                                                                              |
 | `onUpdateNode`             | `func`                     | `true`       | Called when a node is moved.                                                                                                                                                                |
 | `onDeleteNode`             | `func`                     | `true`       | Called when a node is deleted.                                                                                                                                                              |
-| `onSelectEdge`             | `func`                     | `true`       | Called when an edge is selected.                                                                                                                                                            |
+| `onSelectEdge`             | `func`                     | `true`       | Called when an edge is selected. |
 | `onCreateEdge`             | `func`                     | `true`       | Called when an edge is created.                                                                                                                                                             |
 | `onSwapEdge`               | `func`                     | `true`       | Called when an edge `'target'` is swapped.                                                                                                                                                  |
 | `onDeleteEdge`             | `func`                     | `true`       | Called when an edge is deleted.                                                                                                                                                             |
 | `onBackgroundClick`        | `func`                     | `false`      | Called when the background is clicked.  |                                                                                                                         
 | `onArrowClicked`        | `func`                     | `false`      | Called when the arrow head is clicked. |
+| `onUndo`                | `func` | `false` | A function called when Ctrl-Z is activated. React-digraph does not keep track of actions, this must be implemented in the client website. |
+| `onCopySelected` | `func` | `false` | A function called when Ctrl-C is activated. React-digraph does not keep track of copied nodes or edges, the this must be implemented in the client website. |
+| `onPasteSelected` | `func` | `false` | A function called when Ctrl-V is activated. React-digraph does not keep track of copied nodes or edges, the this must be implemented in the client website.
 | `canDeleteNode`            | `func`                     | `false`      | Called before a node is deleted.                                                                                                                                                            |
 | `canCreateEdge`            | `func`                     | `false`      | Called before an edge is created.                                                                                                                                                           |
 | `canDeleteEdge`            | `func`                     | `false`      | Called before an edge is deleted.                                                                                                                                                           |
@@ -238,7 +245,7 @@ All props are detailed below.
 | `edgeArrowSize`            | `number`                   | `false`      | Edge arrow size in pixels. Default 8. Set to 0 to hide arrow.                                                                                                                                                                           |
 | `zoomDelay`                | `number`                   | `false`      | Delay before zoom occurs.                                                                                                                                                                   |
 | `zoomDur`                  | `number`                   | `false`      | Duration of zoom transition.                                                                                                                                                                |
-| `showGraphControls`        | `boolean`                  | `false`      | Whether to show zoom controls.                                                                                                                                                              |
+| `showGraphControls`        | `boolean`                  | `false`      | Whether to show zoom controls. |
 | `layoutEngineType`         | `typeof LayoutEngineType`  | `false`      | Uses a pre-programmed layout engine, such as `'SnapToGrid'`                                                                                                                                 |
 | `rotateEdgeHandle`         | `boolean`                  | `false`      | Whether to rotate edge handle with edge when a node is moved                                                                                                                                |
 | `centerNodeOnMove`         | `boolean`                  | `false`      | Whether the node should be centered on cursor when moving a node                                                                                                                            |
@@ -281,6 +288,9 @@ Prop Types:
   nodeSubtypes: any;
   edgeTypes: any;
   selected: any;
+  selectedNodes: INode[];
+  selectedEdges: IEdge[];
+  onSelect?: ({ nodes: INode[], edges: IEdge[]) => void,
   onBackgroundClick?: (x: number, y: number) => void;
   onDeleteNode: (selected: any, nodeId: string, nodes: any[]) => void;
   onSelectNode: (node: INode | null) => void;

--- a/__tests__/components/graph-controls.test.js
+++ b/__tests__/components/graph-controls.test.js
@@ -1,9 +1,7 @@
 // @flow
 
 import * as React from 'react';
-
 import { shallow } from 'enzyme';
-
 import GraphControls from '../../src/components/graph-controls';
 
 describe('GraphControls component', () => {

--- a/__tests__/components/graph-view.test.js
+++ b/__tests__/components/graph-view.test.js
@@ -407,17 +407,22 @@ describe('GraphView component', () => {
       expect(result.props.targetNode).toEqual(nodes[1]);
     });
 
-    it('handles missing nodes', () => {
+    it('returns null when sourceNode is not found', () => {
       const edge = {
-        source: 'a',
+        source: 'fake',
         target: 'b',
       };
       const result = instance.getEdgeComponent(edge);
+      expect(result).toEqual(null);
+    });
 
-      expect(result.type.prototype.constructor.name).toEqual('Edge');
-      expect(result.props.data).toEqual(edge);
-      expect(result.props.sourceNode).toEqual(null);
-      expect(result.props.targetNode).toEqual(undefined);
+    it('returns null when targetNode is not found and targetPosition is not defined', () => {
+      const edge = {
+        source: 'a',
+        target: 'fake',
+      };
+      const result = instance.getEdgeComponent(edge);
+      expect(result).toEqual(null);
     });
 
     it('handles a targetPosition', () => {

--- a/src/components/graph-controls.js
+++ b/src/components/graph-controls.js
@@ -25,8 +25,8 @@ import { DEFAULT_MAX_ZOOM, DEFAULT_MIN_ZOOM, SLIDER_STEPS } from '../constants';
 import { useZoomLevelToSliderValue } from '../hooks/useZoomLevelToSliderValue';
 import faExpand from '@fortawesome/fontawesome-free/svgs/solid/expand.svg';
 
-const parsedIcon = Parse(faExpand); //  parse SVG once
-const ExpandIcon = () => parsedIcon; // convert SVG to react component
+const parsedExpandIcon = Parse(faExpand); //  parse SVG once
+const ExpandIcon = () => parsedExpandIcon; // convert SVG to react component
 
 type IGraphControlProps = {
   maxZoom?: number,

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -27,6 +27,7 @@ export type IBBox = {
 };
 
 export type IGraphViewProps = {
+  allowMultiselect?: boolean,
   backgroundFillId?: string,
   disableBackspace?: boolean,
   edges: any[],
@@ -50,6 +51,8 @@ export type IGraphViewProps = {
   nodeTypes: any,
   readOnly?: boolean,
   selected?: null | any,
+  selectedNodes?: null | INode[],
+  selectedEdges?: null | IEdge[],
   showGraphControls?: boolean,
   zoomDelay?: number,
   zoomDur?: number,
@@ -72,6 +75,7 @@ export type IGraphViewProps = {
     selectedNode: INode,
     xyCoords?: { x: number, y: number }
   ) => void,
+  onSelect?: ({ nodes: INode[] | null, edges: IEdge[] | null }) => void,
   onSelectEdge?: (selectedEdge: IEdge) => void,
   onSelectNode?: (node: INode | null, event: any) => void,
   onSwapEdge?: (sourceNode: INode, targetNode: INode, edge: IEdge) => void,

--- a/src/components/highlight-area.js
+++ b/src/components/highlight-area.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default React.forwardRef(function HighlightArea(props, ref) {
+  const { startPoint, endPoint } = props;
+  const width = endPoint.x - startPoint.x;
+  const height = endPoint.y - startPoint.y;
+
+  return (
+    <rect
+      className="highlight-area"
+      width={Math.abs(width)}
+      height={Math.abs(height)}
+      ref={ref}
+      x={width > 0 ? startPoint.x : endPoint.x}
+      y={height > 0 ? startPoint.y : endPoint.y}
+      style={{
+        fill: 'rgb(0, 149, 210)',
+        fillOpacity: 0.15,
+        stroke: 'rgba(57, 165, 209, 0.5)',
+        strokeWidth: 2,
+      }}
+    ></rect>
+  );
+});

--- a/src/examples/app.scss
+++ b/src/examples/app.scss
@@ -77,6 +77,19 @@ button {
       margin-right: 5px;
     }
   }
+
+  .pan-list {
+    margin-left: 10px;
+  }
+
+  .allow-multiselect {
+    display: inline-block;
+    margin-left: 10px;
+
+    > label > input {
+      vertical-align: middle;
+    }
+  }
 }
 
 .sidebar {

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -221,9 +221,14 @@ type IGraphProps = {};
 type IGraphState = {
   graph: any,
   selected: any,
+  selectedNodes: null | INode[],
+  selectedEdges: null | IEdge[],
   totalNodes: number,
-  copiedNode: any,
+  copiedNode: null | INode,
+  copiedNodes: null | INode[],
+  copiedEdges: null | IEdge[],
   layoutEngineType?: LayoutEngineType,
+  allowMultiselect: boolean,
 };
 
 class Graph extends React.Component<IGraphProps, IGraphState> {
@@ -234,10 +239,15 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
 
     this.state = {
       copiedNode: null,
+      copiedNodes: null,
+      copiedEdges: null,
       graph: sample,
       layoutEngineType: undefined,
       selected: null,
+      selectedNodes: null,
+      selectedEdges: null,
       totalNodes: sample.nodes.length,
+      allowMultiselect: true,
     };
 
     this.GraphView = React.createRef();
@@ -343,6 +353,13 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
     this.setState({ selected: viewEdge });
   };
 
+  onSelect = ({ nodes, edges }: { nodes: INode[], edges: IEdge[] }) => {
+    this.setState({
+      selectedNodes: nodes,
+      selectedEdges: edges,
+    });
+  };
+
   // Updates the graph with a new node
   onCreateNode = (x: number, y: number) => {
     const graph = this.state.graph;
@@ -367,16 +384,10 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
 
   // Deletes a node from the graph
   onDeleteNode = (viewNode: INode, nodeId: string, nodeArr: INode[]) => {
+    // Note: onDeleteEdge is also called from react-digraph for connected nodes
     const graph = this.state.graph;
-    // Delete any connected edges
-    const newEdges = graph.edges.filter((edge, i) => {
-      return (
-        edge.source !== viewNode[NODE_KEY] && edge.target !== viewNode[NODE_KEY]
-      );
-    });
 
     graph.nodes = nodeArr;
-    graph.edges = newEdges;
 
     this.setState({ graph, selected: null });
   };
@@ -450,38 +461,117 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
   };
 
   onCopySelected = () => {
-    if (this.state.selected.source) {
+    const { selected, selectedNodes, selectedEdges } = this.state;
+
+    if (selected?.source) {
       console.warn('Cannot copy selected edges, try selecting a node instead.');
 
       return;
     }
 
-    const x = this.state.selected.x + 10;
-    const y = this.state.selected.y + 10;
-
-    this.setState({
-      copiedNode: { ...this.state.selected, x, y },
-    });
+    // Track the copied elements separately from other
+    // selected elements in a similar manner to how your OS works.
+    if (selectedNodes != null) {
+      this.setState({
+        copiedNodes: [...selectedNodes],
+        copiedEdges: [...selectedEdges],
+      });
+    } else {
+      this.setState({
+        copiedNode: { ...selected },
+      });
+    }
   };
 
   // Pastes the selected node to mouse position
-  onPasteSelected = (node: INode, mousePosition?: [number, number]) => {
-    const graph = this.state.graph;
+  onPasteSelected = (
+    // node parameter should be deprecated
+    // https://github.com/uber/react-digraph/issues/292
+    node: INode | null,
+    mousePosition?: [number, number]
+  ) => {
+    const { graph, copiedNode, copiedNodes, copiedEdges } = this.state;
+    const [mouseX, mouseY] = mousePosition || [copiedNode.x, copiedNode.y];
 
-    const newNode = {
-      ...node,
-      id: Date.now(),
-      x: mousePosition ? mousePosition[0] : node.x,
-      y: mousePosition ? mousePosition[1] : node.y,
-    };
+    if (copiedNodes == null && copiedNode !== null) {
+      // Paste a single node is only run if allowMultiselect is false
+      const newNode = {
+        ...node,
+        id: Date.now(),
+        x: mousePosition ? mousePosition[0] : node.x,
+        y: mousePosition ? mousePosition[1] : node.y,
+      };
 
-    graph.nodes = [...graph.nodes, newNode];
-    this.forceUpdate();
+      graph.nodes = [...graph.nodes, newNode];
+
+      // Select the new node
+      this.setState({
+        selected: newNode,
+      });
+    } else if (copiedNodes !== null) {
+      // Paste multiple nodes is used if allowMultiselect is true
+      let cornerX, cornerY;
+
+      copiedNodes.forEach(copiedNode => {
+        // find left-most node and record x position
+        if (cornerX == null || copiedNode.x < cornerX) {
+          cornerX = copiedNode.x;
+        }
+
+        // find top-most node and record y position
+        if (cornerY == null || copiedNode.y < cornerY) {
+          cornerY = copiedNode.y;
+        }
+      });
+
+      // Keep track of the mapping of old IDs to new IDs
+      // so we can recreate the edges
+      const newIDs = {};
+
+      // Every node position is relative to the top and left-most corner
+      const newNodes = copiedNodes.map(copiedNode => {
+        const x = mouseX + (copiedNode.x - cornerX);
+        const y = mouseY + (copiedNode.y - cornerY);
+        const id = `${copiedNode.id}_${Date.now()}`;
+
+        newIDs[copiedNode.id] = id;
+
+        return {
+          ...copiedNode,
+          id,
+          x,
+          y,
+        };
+      });
+
+      const newEdges = copiedEdges.map(copiedEdge => {
+        return {
+          ...copiedEdge,
+          source: newIDs[copiedEdge.source],
+          target: newIDs[copiedEdge.target],
+        };
+      });
+
+      graph.nodes = [...graph.nodes, ...newNodes];
+      graph.edges = [...graph.edges, ...newEdges];
+
+      // Select the new nodes and edges
+      this.setState({
+        selectedNodes: newNodes,
+        selectedEdges: newEdges,
+      });
+    }
   };
 
   handleChangeLayoutEngineType = (event: any) => {
     this.setState({
       layoutEngineType: (event.target.value: LayoutEngineType | 'None'),
+    });
+  };
+
+  handleMultiselectChange = (event: any) => {
+    this.setState({
+      allowMultiselect: event.target.checked,
     });
   };
 
@@ -497,7 +587,12 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
 
   render() {
     const { nodes, edges } = this.state.graph;
-    const selected = this.state.selected;
+    const {
+      selected,
+      selectedNodes,
+      selectedEdges,
+      allowMultiselect,
+    } = this.state;
     const { NodeTypes, NodeSubtypes, EdgeTypes } = GraphConfig;
 
     return (
@@ -532,17 +627,31 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
               ))}
             </select>
           </div>
+          <div className="allow-multiselect">
+            <label>
+              Multiselect:
+              <input
+                type="checkbox"
+                onChange={this.handleMultiselectChange}
+                checked={allowMultiselect}
+              />
+            </label>
+          </div>
         </div>
         <div id="graph" style={{ height: 'calc(100% - 87px)' }}>
           <GraphView
             ref={el => (this.GraphView = el)}
+            allowMultiselect={allowMultiselect}
             nodeKey={NODE_KEY}
             nodes={nodes}
             edges={edges}
             selected={selected}
+            selectedNodes={selectedNodes}
+            selectedEdges={selectedEdges}
             nodeTypes={NodeTypes}
             nodeSubtypes={NodeSubtypes}
             edgeTypes={EdgeTypes}
+            onSelect={this.onSelect}
             onSelectNode={this.onSelectNode}
             onCreateNode={this.onCreateNode}
             onUpdateNode={this.onUpdateNode}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -19,6 +19,7 @@ $light-color: white;
 $dark-color: black;
 $light-grey: lightgrey;
 $background-color: #f9f9f9;
+$button-size: 31px;
 
 .view-wrapper {
   height: 100%;
@@ -125,15 +126,15 @@ $background-color: #f9f9f9;
     bottom: 30px;
     left: 15px;
     display: grid;
-    grid-template-columns: auto auto;
+    grid-template-columns: auto auto auto;
     grid-gap: 15px;
     align-items: center;
     user-select: none;
 
     > .slider-wrapper {
-      background-color: white;
+      background-color: $light-color;
       color: $primary-color;
-      border: solid 1px lightgray;
+      border: solid 1px $light-grey;
       padding: 6.5px;
       border-radius: 2px;
 
@@ -151,13 +152,13 @@ $background-color: #f9f9f9;
       }
     }
 
-    > .slider-button {
-      background-color: white;
+    .slider-button {
+      background-color: $light-color;
       fill: $primary-color;
-      border: solid 1px lightgray;
+      border: solid 1px $light-grey;
       outline: none;
-      width: 31px;
-      height: 31px;
+      width: $button-size;
+      height: $button-size;
       border-radius: 2px;
       cursor: pointer;
       margin: 0;

--- a/src/utilities/graph-util.js
+++ b/src/utilities/graph-util.js
@@ -16,7 +16,7 @@
 */
 
 import { type IEdge } from '../components/edge';
-import { type INode } from '../components/node';
+import { type INode, type IPoint } from '../components/node';
 import fastDeepEqual from 'fast-deep-equal';
 
 export type INodeMapNode = {
@@ -174,6 +174,55 @@ class GraphUtils {
 
   static isEqual(prevNode: any, newNode: any) {
     return fastDeepEqual(prevNode, newNode);
+  }
+
+  static findNodesWithinArea(start: IPoint, end: IPoint, nodes: INode[]) {
+    const smallerX = Math.min(start.x, end.x);
+    const smallerY = Math.min(start.y, end.y);
+    const largerX = Math.max(end.x, start.x);
+    const largerY = Math.max(end.y, start.y);
+
+    const foundNodes = nodes.filter(node => {
+      return (
+        node.x >= smallerX &&
+        node.x <= largerX &&
+        node.y >= smallerY &&
+        node.y <= largerY
+      );
+    });
+
+    return foundNodes;
+  }
+
+  static findConnectedEdgesForNodes(
+    nodes: INode[],
+    edgesMap: any,
+    nodeKey: string
+  ) {
+    const foundEdges = [];
+
+    // using for loop to increase search speed
+    for (let i = 0; i < nodes.length; i++) {
+      const nodeA = nodes[i];
+
+      for (let j = i; j < nodes.length; j++) {
+        const nodeB = nodes[j];
+
+        // Find edges where A is connected to B or B is connected to A
+        const edgeAB = edgesMap[`${nodeA[nodeKey]}_${nodeB[nodeKey]}`];
+        const edgeBA = edgesMap[`${nodeB[nodeKey]}_${nodeA[nodeKey]}`];
+
+        if (edgeAB != null) {
+          foundEdges.push(edgeAB.edge);
+        }
+
+        if (edgeBA != null) {
+          foundEdges.push(edgeBA.edge);
+        }
+      }
+    }
+
+    return foundEdges;
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -97,6 +97,7 @@ declare module 'react-digraph' {
   export const Edge: React.Component<IEdgeProps>;
 
   export type IGraphViewProps = {
+    allowMultiSelect?: boolean;
     backgroundFillId?: string;
     edges: any[];
     edgeArrowSize?: number;


### PR DESCRIPTION
New properties:

- allowMultiSelect
- selectedNodes
- selectedEdges
- showHelp
- onSelectNodes
- onSelectEdges

New help menu can be activated with the showHelp property. 
Enable multiple selection with the allowMultiSelect property.

![Peek 2021-01-07 22-17](https://user-images.githubusercontent.com/161761/104054108-54d8a200-51a1-11eb-9928-6df35982099f.gif)

Use Ctrl/Cmd+Shift+Mouse to select multiple nodes. If implemented in the client code, Ctrl+C and Ctrl+V will copy and paste nodes.

![Peek 2021-01-07 22-18](https://user-images.githubusercontent.com/161761/104054113-57d39280-51a1-11eb-8fb5-ffacb0d264dd.gif)

Deleting multiple nodes will call the onDeleteNode callback function multiple times (could be changed to a bulk function in the future.

![Peek 2021-01-07 22-20](https://user-images.githubusercontent.com/161761/104054132-5e620a00-51a1-11eb-8378-8c36589272b8.gif)

**Possible future updates:**

- Deprecate `onSelectNode` (singular)
- Deprecate `onSelectEdge` (singular)
- Deprecate `selected`, prefer `selectedNodes` and `selectedEdges`
- Deprecate `onDeleteNode`
- Add `onDeleteNodes`
- Make copy functionality store copied nodes within graph-view (tangentially related to this update)
- Make `allowMultiSelect=true` the default