### PR TITLE
Allow loopback edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ All props are detailed below.
 | `nodes`                    | `Array<INode>`             | `true`       | Array of graph nodes.                                                                                                                                                                       |
 | `edges`                    | `Array<IEdge>`             | `true`       | Array of graph edges.                                                                                                                                                                       |
 | `allowMultiselect`         | `boolean`                  | `false`      | Use Ctrl-Shift-LeftMouse to draw a multiple selection box |
+| `allowLoopbackEdge`         | `boolean`                  | `false`      | When set to `true` edges that have the same start and end node are allowed to be set by the user.|
 | `selected`                 | `object`                   | `true`       | The currently selected graph entity. |
 | `selectedNodes`                 | `Array<INode>`                   | `false`       | If allowMultiselect is true, this should be the currently selected array of nodes. |
 | `selectedEdges`                 | `Array<IEdge>`                   | `true`       | If allowMultiselect is true, this should be the currently selected array of edges. |

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1009,11 +1009,14 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
   createNewEdge() {
     const { canCreateEdge, nodeKey, onCreateEdge } = this.props;
-    const { edgesMap, edgeEndNode, hoveredNodeData } = this.state;
+    const { edgesMap, hoveredNodeData } = this.state;
 
     if (!hoveredNodeData) {
       return;
     }
+
+    // If no edgeEndNode is defined it will add the edge to itself.
+    const edgeEndNode = this.state.edgeEndNode || hoveredNodeData;
 
     this.removeCustomEdge();
 
@@ -1023,7 +1026,6 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
       if (
         edgesMap &&
-        hoveredNodeData !== edgeEndNode &&
         canCreateEdge &&
         canCreateEdge(hoveredNodeData, edgeEndNode) &&
         !edgesMap[mapId1] &&
@@ -1044,7 +1046,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
   handleNodeUpdate = (position: any, nodeId: string, shiftKey: boolean) => {
     const { onUpdateNode, readOnly } = this.props;
-    const { draggingEdge, hoveredNode, edgeEndNode } = this.state;
+    const { draggingEdge, hoveredNode } = this.state;
 
     if (readOnly) {
       return;
@@ -1052,7 +1054,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     // Detect if edge is being drawn and link to hovered node
     // This will handle a new edge
-    if (shiftKey && hoveredNode && edgeEndNode) {
+    if (shiftKey && hoveredNode) {
       this.createNewEdge();
     } else {
       if (draggingEdge) {

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -89,6 +89,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     zoomDur: 750,
     rotateEdgeHandle: true,
     centerNodeOnMove: true,
+    allowLoopbackEdge: false,
   };
 
   static getDerivedStateFromProps(
@@ -1009,14 +1010,11 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
   createNewEdge() {
     const { canCreateEdge, nodeKey, onCreateEdge } = this.props;
-    const { edgesMap, hoveredNodeData } = this.state;
+    const { edgesMap, edgeEndNode, hoveredNodeData } = this.state;
 
     if (!hoveredNodeData) {
       return;
     }
-
-    // If no edgeEndNode is defined it will add the edge to itself.
-    const edgeEndNode = this.state.edgeEndNode || hoveredNodeData;
 
     this.removeCustomEdge();
 
@@ -1046,7 +1044,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
   handleNodeUpdate = (position: any, nodeId: string, shiftKey: boolean) => {
     const { onUpdateNode, readOnly } = this.props;
-    const { draggingEdge, hoveredNode } = this.state;
+    const { draggingEdge, hoveredNode, edgeEndNode } = this.state;
 
     if (readOnly) {
       return;
@@ -1054,7 +1052,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
     // Detect if edge is being drawn and link to hovered node
     // This will handle a new edge
-    if (shiftKey && hoveredNode) {
+    if (shiftKey && hoveredNode && edgeEndNode) {
       this.createNewEdge();
     } else {
       if (draggingEdge) {
@@ -1091,9 +1089,14 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
   handleNodeMouseEnter = (event: any, data: any) => {
     const { draggingEdge, hoveredNodeData } = this.state;
+    const { allowLoopbackEdge } = this.props;
 
     // hovered is false when creating edges
-    if (hoveredNodeData && data !== hoveredNodeData && draggingEdge) {
+    if (
+      hoveredNodeData &&
+      (data !== hoveredNodeData || allowLoopbackEdge) &&
+      draggingEdge
+    ) {
       this.setState({
         edgeEndNode: data,
       });

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -408,14 +408,11 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
       type,
     };
 
-    // Only add the edge when the source node is not the same as the target
-    if (viewEdge.source !== viewEdge.target) {
-      graph.edges = [...graph.edges, viewEdge];
-      this.setState({
-        graph,
-        selected: viewEdge,
-      });
-    }
+    graph.edges = [...graph.edges, viewEdge];
+    this.setState({
+      graph,
+      selected: viewEdge,
+    });
   };
 
   // Called when an edge is reattached to a different target.

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -661,6 +661,7 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
             onCopySelected={this.onCopySelected}
             onPasteSelected={this.onPasteSelected}
             layoutEngineType={this.state.layoutEngineType}
+            allowLoopbackEdge={true}
           />
         </div>
       </>

--- a/src/helpers/edge-helpers.js
+++ b/src/helpers/edge-helpers.js
@@ -222,6 +222,35 @@ export function getPathDescription(
     viewWrapperElem
   );
 
+  if (sourceNode === targetNode) {
+    const arrowOffset = nodeSize * 0.8;
+
+    const returningLinePoints = [
+      {
+        x: srcX - srcOff.xOff + nodeSize / 2,
+        y: srcY - srcOff.yOff,
+      },
+      {
+        x: srcX - srcOff.xOff + arrowOffset,
+        y: srcY - srcOff.yOff,
+      },
+      {
+        x: srcX - srcOff.xOff + arrowOffset,
+        y: srcY - srcOff.yOff - arrowOffset,
+      },
+      {
+        x: srcX - srcOff.xOff,
+        y: srcY - srcOff.yOff - arrowOffset,
+      },
+      {
+        x: srcX - trgOff.xOff,
+        y: srcY - trgOff.yOff - nodeSize / 2,
+      },
+    ];
+
+    return getLine(returningLinePoints);
+  }
+
   const linePoints = [
     {
       x: srcX - srcOff.xOff,

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -76,6 +76,7 @@ $button-size: 31px;
   }
 
   .edge {
+    fill: transparent;
     color: $light-color;
     stroke: $primary-color;
     stroke-width: 2px;


### PR DESCRIPTION
- Added `allowLoopbackEdge` property
- If `allowLoopbackEdge` is set to true, the mouse enter allows to set the `edgeEndNode` to the node from which the edge started.