### PR TITLE
Fixed the slider CSS so that all elements are centered

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -140,8 +140,7 @@ $button-size: 31px;
 
       > span {
         display: inline-block;
-        vertical-align: top;
-        margin-top: 4px;
+        vertical-align: middle;
       }
 
       > .slider {
@@ -149,6 +148,7 @@ $button-size: 31px;
         margin-left: 4px;
         margin-right: 4px;
         cursor: pointer;
+        vertical-align: middle;
       }
     }
 
@@ -162,6 +162,10 @@ $button-size: 31px;
       border-radius: 2px;
       cursor: pointer;
       margin: 0;
+
+      > svg {
+        vertical-align: middle;
+      }
     }
   }
 


### PR DESCRIPTION
Old:
![Screenshot_2021-03-23_13-37-03](https://user-images.githubusercontent.com/161761/112214823-e2dafb00-8bdc-11eb-917e-e3b6a8a13b04.png)

New (ignore size differences, focus on vertical alignment):
![Screenshot_2021-03-23_13-36-49](https://user-images.githubusercontent.com/161761/112214826-e3739180-8bdc-11eb-867d-4f2aad10186f.png)
