### PR TITLE
Deprecated old features and improved multiselect for v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,29 @@
 
 A React component which makes it easy to create a directed graph editor without implementing any of the SVG drawing or event handling logic.
 
-## Important v5.0.0 Information
-Version 5.0.0 is a breaking change to some of the API interfaces. Many of the component attributes are the same, and the data format is the same, but there
-have been some necessary changes to improve the API, make the component faster, and add new features. Many changes will be listed below in the deprecation notes section. If you notice a problem, please use the `^4.0.0` versions of the package and refer to the legacy documentation in the `v4.x.x` git branch.
+## Important v8.0.0 Information
+Version 8.0.0 introduces multi-select nodes and edges using Ctrl-Shift-Mouse events (Cmd-Shift-mouse for Mac). This requires a breaking change. Instead of onSelectNode/Edge, you'll only provide one onSelect function callback and a `selected` object with `{ nodes: Map, and edges: Map }` as the parameter format. The [typings folder](typings/index.d.ts) has the exact type definition for these attributes. When either edges or nodes are selected the onSelect function will fire with the object. You will have to handle all nodes and edges selected, or if there is only one then you will have to determine if it's a node or edge within the onSelect function.
+
+To disable multi-select you can set `allowMultiselect` to `false`, which disables the Ctrl-Shift-mouse event, but we will still use the `onSelect` function. Both `onSelectNode` and `onSelectEdge` are deprecated.
+
+Breaking changes: 
+
+- `onPasteSelected` now accepts a `SelectionT` object for the first parameter
+- `onPasteSelected` now accepts an `IPoint` instead 
+of a `XYCoords` array for the second parameter.
+- `onDeleteSelected` is added which takes a `SelectionT` parameter.
+- `onSelect` is added, which accepts `SelectionT` and `Event` parameters.
+- `onUpdateNode` accepts a Map of updated nodes in the second parameter (for example, if multiple nodes are moved).
+- `selected` is a new property to track selected nodes and edges. It is a `SelectionT` type.
+- `canDeleteSelected` takes the place of `canDeleteNode` and `canDeleteEdge`. It accepts a `SelectionT` type as a parameter.
+- `onDeleteNode` is removed
+- `onDeleteEdge` is removed
+- `selectedNode` is removed
+- `selectedEdge` is removed
+- `canDeleteNode` is removed
+- `canDeleteEdge` is removed
+- `selectedNodes` is removed
+- `selectedEdges` is removed
 
 ## Installation
 
@@ -15,6 +35,7 @@ npm install --save react-digraph
 ```
 
 If you don't have the following peerDependenies, make sure to install them:
+
 ```bash
 npm install --save react react-dom
 ```
@@ -111,7 +132,7 @@ class Graph extends Component {
                     nodeTypes={NodeTypes}
                     nodeSubtypes={NodeSubtypes}
                     edgeTypes={EdgeTypes}
-                    allowMultiselect={true}
+                    allowMultiselect={true} // true by default, set to false to disable multi select.
                     onSelect={this.onSelect}
                     onCreateNode={this.onCreateNode}
                     onUpdateNode={this.onUpdateNode}
@@ -181,7 +202,7 @@ To run the example:
 
 ```bash
 npm install
-npm run serve
+npm run example
 ```
 
 A webpage will open in your default browser automatically.
@@ -190,6 +211,10 @@ A webpage will open in your default browser automatically.
 - To add edges, hold shift and click/drag to between nodes.
 - To delete a node or edge, click on it and press delete.
 - Click and drag nodes to change their position.
+- To select multiple nodes, press Ctrl+Shift then click and drag the mouse.
+- You may copy and paste selected nodes and edges with Ctrl+C and Ctrl+V
+
+* Note: On Mac computers, use Cmd instead of Ctrl.
 
 All props are detailed below.
 
@@ -201,31 +226,24 @@ All props are detailed below.
 | `nodeKey`                  | `string`                   | `true`       | Key for D3 to update nodes(typ. UUID).                                                                                                                                                      |
 | `nodes`                    | `Array<INode>`             | `true`       | Array of graph nodes.                                                                                                                                                                       |
 | `edges`                    | `Array<IEdge>`             | `true`       | Array of graph edges.                                                                                                                                                                       |
-| `allowMultiselect`         | `boolean`                  | `false`      | Use Ctrl-Shift-LeftMouse to draw a multiple selection box |
+| `allowMultiselect`         | `boolean`    | `false`      | (default true) Use Ctrl-Shift-LeftMouse to draw a multiple selection box. |
 | `selected`                 | `object`                   | `true`       | The currently selected graph entity. |
-| `selectedNodes`            | `Map<string, INode>`                   | `false`       | If allowMultiselect is true, this should be the currently selected array of nodes. |
-| `selectedEdges`            | `Map<string, IEdge>`                   | `false`       | If allowMultiselect is true, this should be the currently selected array of edges. |
 | `nodeTypes`                | `object`                   | `true`       | Config object of available node types.                                                                                                                                                      |
 | `nodeSubtypes`             | `object`                   | `true`       | Config object of available node subtypes.                                                                                                                                                   |
 | `edgeTypes`                | `object`                   | `true`       | Config object of available edge types.                                                                                                                                                      |
 | `onSelect`             | `func`                     | `false`       | Called when nodes are selected when `allowMultiselect` is true. Is passed an object with nodes and edges included. |
-| `onSelectNode`             | `func`                     | `false`       | To be Deprecated: Called when a node is selected. |
 | `onCreateNode`             | `func`                     | `true`       | Called when a node is created.                                                                                                                                                              |
 | `onContextMenu`            | `func`                     | `true`       | Called when contextmenu event triggered.                                                                                                                                                              |
-| `onUpdateNode`             | `func`                     | `true`       | Called when a node is moved.                                                                                                                                                                |
-| `onDeleteNode`             | `func`                     | `true`       | Called when a node is deleted. This function should also delete connected edges. |
-| `onSelectEdge`             | `func`                     | `true`       | To be Deprecated: Called when an edge is selected. |
-| `onCreateEdge`             | `func`                     | `true`       | Called when an edge is created.                                                                                                                                                             |
-| `onSwapEdge`               | `func`                     | `true`       | Called when an edge `'target'` is swapped.                                                                                                                                                  |
-| `onDeleteEdge`             | `func`                     | `true`       | Called when an edge is deleted. This function is not called when multiple nodes and edges are selected using the allowMultiselect feature. Only when a single edge is selected.  |
+| `onUpdateNode`             | `func`                     | `true`       | Called when a node is moved.|
+| `onCreateEdge`             | `func`                     | `true`       | Called when an edge is created.|
+| `onSwapEdge`               | `func`                     | `true`       | Called when an edge `'target'` is swapped.|
 | `onBackgroundClick`        | `func`                     | `false`      | Called when the background is clicked.  |                                                                                                                         
 | `onArrowClicked`        | `func`                     | `false`      | Called when the arrow head is clicked. |
 | `onUndo`                | `func` | `false` | A function called when Ctrl-Z is activated. React-digraph does not keep track of actions, this must be implemented in the client website. |
 | `onCopySelected` | `func` | `false` | A function called when Ctrl-C is activated. React-digraph does not keep track of copied nodes or edges, the this must be implemented in the client website. |
 | `onPasteSelected` | `func` | `false` | A function called when Ctrl-V is activated. React-digraph does not keep track of copied nodes or edges, the this must be implemented in the client website.
-| `canDeleteNode`            | `func`                     | `false`      | Called before a node is deleted.                                                                                                                                                            |
-| `canCreateEdge`            | `func`                     | `false`      | Called before an edge is created.                                                                                                                                                           |
-| `canDeleteEdge`            | `func`                     | `false`      | Called before an edge is deleted.                                                                                                                                                           |
+| `canDeleteSelected` | `func` | `false` | takes the place of `canDeleteNode` and `canDeleteEdge`. It accepts a `SelectionT` type as a parameter. It is called before a node or edge is deleted. The function should return a boolean.
+| `canCreateEdge`            | `func`                     | `false`      | Called before an edge is created.|
 | `canSwapEdge`              | `func`                     | `false`      | Called before an edge 'target' is swapped.
 | `afterRenderEdge`          | `func`                     | `false`      | Called after an edge is rendered.                                                                                                                                                           |
 | `renderNode`               | `func`                     | `false`      | Called to render node geometry.                                                                                                                                                             |

--- a/__tests__/components/graph-view.test.js
+++ b/__tests__/components/graph-view.test.js
@@ -413,6 +413,7 @@ describe('GraphView component', () => {
         target: 'b',
       };
       const result = instance.getEdgeComponent(edge);
+
       expect(result).toEqual(null);
     });
 
@@ -422,6 +423,7 @@ describe('GraphView component', () => {
         target: 'fake',
       };
       const result = instance.getEdgeComponent(edge);
+
       expect(result).toEqual(null);
     });
 
@@ -480,7 +482,7 @@ describe('GraphView component', () => {
     });
 
     it('returns true when the edge is selected', () => {
-      selected = edge;
+      selected = { edges: new Map([[`${edge.source}_${edge.target}`, edge]]) };
       output.setProps({
         edges,
         selected,
@@ -492,10 +494,12 @@ describe('GraphView component', () => {
     });
 
     it('returns false when the edge is not selected', () => {
-      selected = {
+      const edge = {
         source: 'b',
         target: 'c',
       };
+
+      selected = { edges: null }; // no edges selected
       output.setProps({
         edges,
         selected,
@@ -648,7 +652,7 @@ describe('GraphView component', () => {
     it('returns a selected node', () => {
       output.setProps({
         nodes: [node],
-        selected: node,
+        selected: { nodes: new Map([[node.id, node]]) },
       });
       const result = instance.getNodeComponent('test', node, 0);
 
@@ -1228,26 +1232,29 @@ describe('GraphView component', () => {
   describe('handleMultipleSelected method', () => {
     beforeEach(() => {
       output.setProps({
-        edges: [{ source: 'a', target: 'b' }, { source: 'b', target: 'c' }],
+        edges: [
+          { source: 'a', target: 'b' },
+          { source: 'b', target: 'c' },
+        ],
         nodes: [{ id: 'a', x: 1, y: 1 }, { id: 'b', x: 2, y: 2 }, { id: 'c' }],
         nodeKey: 'id',
       });
     });
-    
+
     it('onSelect', () => {
       const selectionStart = { x: 1, y: 1 };
       const selectionEnd = { x: 100, y: 100 };
-      
+
       let actual = null;
+
       output.setProps({
-        onSelect: (selected) => {
+        onSelect: selected => {
           actual = selected;
-        }
+        },
       });
       instance.handleMultipleSelected(selectionStart, selectionEnd);
       expect(actual.nodes.size).toEqual(2);
       expect(actual.edges.size).toEqual(1);
     });
   });
-
 });

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "opn-cli": "3.1.0",
     "prettier": "^1.19.1",
     "prop-types": "^15.6.0",
+    "react": "^16.14.0",
     "react-ace": "^6.1.4",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.0.0",

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -19,6 +19,11 @@ import { type LayoutEngineType } from '../utilities/layout-engine/layout-engine-
 import { type IEdge } from './edge';
 import { type INode } from './node';
 
+export type IPoint = {
+  x: number,
+  y: number,
+};
+
 export type IBBox = {
   x: number,
   y: number,
@@ -28,7 +33,7 @@ export type IBBox = {
 
 export type SelectionT = {
   nodes: Map<string, INode> | null,
-  edges: Map<string, INode> | null,
+  edges: Map<string, IEdge> | null,
 };
 
 export type IGraphViewProps = {
@@ -55,15 +60,12 @@ export type IGraphViewProps = {
   nodeSubtypes: any,
   nodeTypes: any,
   readOnly?: boolean,
-  selected?: null | any,
-  selectedNodes?: null | INode[],
-  selectedEdges?: null | IEdge[],
+  selected?: null | SelectionT,
   showGraphControls?: boolean,
   zoomDelay?: number,
   zoomDur?: number,
   canCreateEdge?: (startNode?: INode, endNode?: INode) => boolean,
-  canDeleteEdge?: (selected: any) => boolean,
-  canDeleteNode?: (selected: any) => boolean,
+  canDeleteSelected?: (selected: SelectionT) => boolean,
   canSwapEdge?: (
     sourceNode: INode,
     hoveredNode: INode | null,
@@ -74,18 +76,15 @@ export type IGraphViewProps = {
   onCreateEdge?: (sourceNode: INode, targetNode: INode) => void,
   onCreateNode?: (x: number, y: number, event: any) => void,
   onContextMenu?: (x: number, y: number, event: any) => void,
-  onDeleteEdge?: (selectedEdge: IEdge, edges: IEdge[]) => void,
-  onDeleteNode?: (selected: any, nodeId: string, nodes: any[]) => void,
-  onPasteSelected?: (
-    selectedNode: INode,
-    xyCoords?: { x: number, y: number }
-  ) => void,
-  onSelect?: (selected: SelectionT) => void,
-  onSelectEdge?: (selectedEdge: IEdge) => void,
-  onSelectNode?: (node: INode | null, event: any) => void,
+  onDeleteSelected?: (selected: SelectionT) => void,
+  onPasteSelected?: (selected?: SelectionT | null, xyCoords?: IPoint) => void,
+  onSelect?: (selected: SelectionT, event?: any) => void,
   onSwapEdge?: (sourceNode: INode, targetNode: INode, edge: IEdge) => void,
   onUndo?: () => void,
-  onUpdateNode?: (node: INode) => void,
+  onUpdateNode?: (
+    node: INode,
+    updatedNodes?: Map<string, INode> | null
+  ) => void,
   onArrowClicked?: (selectedEdge: IEdge) => void,
   renderBackground?: (gridSize?: number) => any,
   renderDefs?: () => any,

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -33,11 +33,7 @@ import {
   DEFAULT_NODE_TEXT_MAX_TITLE_CHARS,
 } from '../constants';
 import { calculateOffset } from '../helpers/edge-helpers';
-
-export type IPoint = {
-  x: number,
-  y: number,
-};
+import { type IPoint } from './graph-view-props';
 
 export type INode = {
   title: string,
@@ -79,8 +75,8 @@ type INodeProps = {
   isSelected: boolean,
   layoutEngine?: any,
   viewWrapperElem: HTMLDivElement,
-  centerNodeOnMove: boolean,
-  maxTitleChars: number,
+  centerNodeOnMove?: boolean,
+  maxTitleChars?: number,
 };
 
 function Node({

--- a/src/index.js
+++ b/src/index.js
@@ -29,5 +29,5 @@ export type INodeType = INode;
 export { default as BwdlTransformer } from './utilities/transformers/bwdl-transformer';
 export { GV as GraphView };
 export type LayoutEngineType = LayoutEngineConfigTypes;
-export type { SelectionT } from './components/graph-view-props';
+export type { SelectionT, IPoint } from './components/graph-view-props';
 export default GV;

--- a/src/utilities/graph-util.js
+++ b/src/utilities/graph-util.js
@@ -16,7 +16,8 @@
 */
 
 import { type IEdge } from '../components/edge';
-import { type INode, type IPoint } from '../components/node';
+import { type INode } from '../components/node';
+import { type IPoint } from '../components/graph-view-props';
 import fastDeepEqual from 'fast-deep-equal';
 
 export type INodeMapNode = {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -102,7 +102,7 @@ declare module 'react-digraph' {
   export const Edge: React.Component<IEdgeProps>;
 
   export type IGraphViewProps = {
-    allowMultiSelect?: boolean;
+    allowMultiselect?: boolean;
     backgroundFillId?: string;
     edges: any[];
     edgeArrowSize?: number;
@@ -124,15 +124,12 @@ declare module 'react-digraph' {
     nodeSubtypes: any;
     nodeTypes: any;
     readOnly?: boolean;
-    selected?: null | any;
-    selectedNodes?: null | Map<string, INode>;
-    selectedEdges?: null | Map<string, IEdge>;
+    selected?: null | SelectionT;
     showGraphControls?: boolean;
     zoomDelay?: number;
     zoomDur?: number;
     canCreateEdge?: (startNode?: INode, endNode?: INode) => boolean;
-    canDeleteEdge?: (selected: any) => boolean;
-    canDeleteNode?: (selected: any) => boolean;
+    canDeleteSelected?: (selected: SelectionT) => boolean;
     canSwapEdge?: (
       sourceNode: INode,
       hoveredNode: INode | null,
@@ -142,18 +139,15 @@ declare module 'react-digraph' {
     onCopySelected?: () => void;
     onCreateEdge?: (sourceNode: INode, targetNode: INode) => void;
     onCreateNode?: (x: number, y: number, event: any) => void;
-    onDeleteEdge?: (selectedEdge: IEdge, edges: IEdge[]) => void;
-    onDeleteNode?: (selected: any, nodeId: string, nodes: any[]) => void;
+    onDeleteSelected?: (selected: SelectionT) => void;
     onPasteSelected?: (
-      selectedNode: INode,
-      xyCoords?: { x: number, y: number }
+      selected?: SelectionT | null,
+      xyCoords?: IPoint
     ) => void,
-    onSelect?: (selected: SelectionT) => void;
-    onSelectEdge?: (selectedEdge: IEdge) => void;
-    onSelectNode?: (node: INode | null, event: any) => void;
+    onSelect?: (selected: SelectionT, event?: any) => void;
     onSwapEdge?: (sourceNode: INode, targetNode: INode, edge: IEdge) => void;
     onUndo?: () => void;
-    onUpdateNode?: (node: INode) => void;
+    onUpdateNode?: (node: INode, updatedNodes?: Map<string, INode> | null) => void;
     renderBackground?: (gridSize?: number) => any;
     renderDefs?: () => any;
     renderNode?: (


### PR DESCRIPTION
See the README for changes.

## Important v8.0.0 Information
Version 8.0.0 introduces multi-select nodes and edges using Ctrl-Shift-Mouse events (Cmd-Shift-mouse for Mac). This requires a breaking change. Instead of onSelectNode/Edge, you'll only provide one onSelect function callback and a `selected` object with `{ nodes: Map, and edges: Map }` as the parameter format. The [typings folder](typings/index.d.ts) has the exact type definition for these attributes. When either edges or nodes are selected the onSelect function will fire with the object. You will have to handle all nodes and edges selected, or if there is only one then you will have to determine if it's a node or edge within the onSelect function.

To disable multi-select you can set `allowMultiselect` to `false`, which disables the Ctrl-Shift-mouse event, but we will still use the `onSelect` function. Both `onSelectNode` and `onSelectEdge` are deprecated.

Breaking changes: 

- `onPasteSelected` now accepts a `SelectionT` object for the first parameter
- `onPasteSelected` now accepts an `IPoint` instead 
of a `XYCoords` array for the second parameter.
- `onDeleteSelected` is added which takes a `SelectionT` parameter.
- `onSelect` is added, which accepts `SelectionT` and `Event` parameters.
- `onUpdateNode` accepts a Map of updated nodes in the second parameter (for example, if multiple nodes are moved).
- `selected` is a new property to track selected nodes and edges. It is a `SelectionT` type.
- `canDeleteSelected` takes the place of `canDeleteNode` and `canDeleteEdge`. It accepts a `SelectionT` type as a parameter.
- `onDeleteNode` is removed
- `onDeleteEdge` is removed
- `selectedNode` is removed
- `selectedEdge` is removed
- `canDeleteNode` is removed
- `canDeleteEdge` is removed
- `selectedNodes` is removed
- `selectedEdges` is removed