### PR TITLE
Updated node update method to accept a promise.

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "opn-cli": "3.1.0",
     "prettier": "^1.19.1",
     "prop-types": "^15.6.0",
-    "react": "^16.14.0",
     "react-ace": "^6.1.4",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.0.0",

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -84,7 +84,7 @@ export type IGraphViewProps = {
   onUpdateNode?: (
     node: INode,
     updatedNodes?: Map<string, INode> | null
-  ) => void,
+  ) => void | Promise<any>,
   onArrowClicked?: (selectedEdge: IEdge) => void,
   renderBackground?: (gridSize?: number) => any,
   renderDefs?: () => any,

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -63,7 +63,7 @@ type INodeProps = {
     shiftKey: boolean,
     event?: any
   ) => void,
-  onNodeUpdate: (point: IPoint, id: string, shiftKey: boolean) => void,
+  onNodeUpdate: (point: IPoint, id: string, shiftKey: boolean) => Promise<any>,
   renderNode?: (
     nodeRef: any,
     data: any,
@@ -172,8 +172,21 @@ function Node({
 
       const shiftKey = sourceEvent.shiftKey;
 
-      onNodeSelected(data, data[nodeKey], shiftKey, sourceEvent);
-      onNodeUpdate(position.current, data[nodeKey], shiftKey);
+      const nodeUpdate = onNodeUpdate(
+        position.current,
+        data[nodeKey],
+        shiftKey
+      );
+
+      if (nodeUpdate.then) {
+        nodeUpdate
+          .then(() => {
+            onNodeSelected(data, data[nodeKey], shiftKey, sourceEvent);
+          })
+          .catch(() => {
+            onNodeSelected(data, data[nodeKey], shiftKey, sourceEvent);
+          });
+      }
     },
     [onNodeUpdate, data, nodeKey, onNodeSelected]
   );

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -335,7 +335,7 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
 
   // Called by 'drag' handler, etc..
   // to sync updates from D3 with the graph
-  onUpdateNode = (viewNode: INode) => {
+  onUpdateNode = (viewNode: INode, selectedNodes: Map<string, INode>) => {
     const graph = this.state.graph;
     const i = this.getNodeIndex(viewNode);
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -147,7 +147,7 @@ declare module 'react-digraph' {
     onSelect?: (selected: SelectionT, event?: any) => void;
     onSwapEdge?: (sourceNode: INode, targetNode: INode, edge: IEdge) => void;
     onUndo?: () => void;
-    onUpdateNode?: (node: INode, updatedNodes?: Map<string, INode> | null) => void;
+    onUpdateNode?: (node: INode, updatedNodes?: Map<string, INode> | null) => void | Promise<any>;
     renderBackground?: (gridSize?: number) => any;
     renderDefs?: () => any;
     renderNode?: (


### PR DESCRIPTION
In some client sites the onNodeSelect method was causing a re-render which would reload the original nodes array again, so the onNodeUpdate method was being overwritten with old node position data. This change fixes that by calling onNodeUpdate as a promise and waiting for its return before calling onNodeSelect. This may cause a perceived lag on node selection if the update method is slow, so client sites should optimize the onNodeUpdate method if possible.