### PR TITLE
fix layout engine adjustmentNode mutates position during nodeUpdate

### DIFF
--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -106,4 +106,5 @@ export type IGraphViewProps = {
   rotateEdgeHandle?: boolean,
   centerNodeOnMove?: boolean,
   initialBBox?: IBBox,
+  nodeLocationOverrides?: Object,
 };

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -83,7 +83,8 @@ export type IGraphViewProps = {
   onUndo?: () => void,
   onUpdateNode?: (
     node: INode,
-    updatedNodes?: Map<string, INode> | null
+    updatedNodes?: Map<string, INode> | null,
+    updatedNodePoistion?: Object
   ) => void | Promise<any>,
   onArrowClicked?: (selectedEdge: IEdge) => void,
   renderBackground?: (gridSize?: number) => any,

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1019,7 +1019,6 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       if (nodeMap) {
         if (this.hasLayoutEngine()) {
           this.layoutEngineAdjustNodes();
-          Object.assign(nodeMap.node, position);
         } else {
           Object.assign(nodeMap.node, position);
           this.renderConnectedEdgesFromNode(nodeMap, true);
@@ -1041,7 +1040,8 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
           }
 
           onUpdateNodePromise =
-            onUpdateNode(nodeMap.node, updatedNodes) || Promise.resolve();
+            onUpdateNode(nodeMap.node, updatedNodes, position) ||
+            Promise.resolve();
         }
       }
     }

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -1019,6 +1019,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
       if (nodeMap) {
         if (this.hasLayoutEngine()) {
           this.layoutEngineAdjustNodes();
+          Object.assign(nodeMap.node, position);
         } else {
           Object.assign(nodeMap.node, position);
           this.renderConnectedEdgesFromNode(nodeMap, true);

--- a/src/examples/graph.js
+++ b/src/examples/graph.js
@@ -230,6 +230,7 @@ type IGraphState = {
   copiedEdges: null | IEdge[],
   layoutEngineType?: LayoutEngineType,
   allowMultiselect: boolean,
+  locationOverrides?: Object,
 };
 
 class Graph extends React.Component<IGraphProps, IGraphState> {
@@ -249,6 +250,7 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
       selectedEdges: null,
       totalNodes: sample.nodes.length,
       allowMultiselect: true,
+      locationOverrides: {},
     };
 
     this.GraphView = React.createRef();
@@ -335,12 +337,20 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
 
   // Called by 'drag' handler, etc..
   // to sync updates from D3 with the graph
-  onUpdateNode = (viewNode: INode, selectedNodes: Map<string, INode>) => {
+  onUpdateNode = (
+    viewNode: INode,
+    selectedNodes: Map<string, INode>,
+    position?: Object
+  ) => {
     const graph = this.state.graph;
     const i = this.getNodeIndex(viewNode);
+    const overrides = {
+      ...this.state.locationOverrides,
+      [viewNode.id]: position,
+    };
 
     graph.nodes[i] = viewNode;
-    this.setState({ graph });
+    this.setState({ graph, locationOverrides: overrides });
   };
 
   onSelect = (selected: SelectionT) => {
@@ -602,6 +612,7 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
               <option value={undefined}>None</option>
               <option value={'SnapToGrid'}>Snap to Grid</option>
               <option value={'VerticalTree'}>Vertical Tree</option>
+              <option value={'HorizontalTree'}>Horizontal Tree</option>
             </select>
           </div>
           <div className="pan-list">
@@ -637,6 +648,7 @@ class Graph extends React.Component<IGraphProps, IGraphState> {
             onCopySelected={this.onCopySelected}
             onPasteSelected={this.onPasteSelected}
             layoutEngineType={layoutEngineType}
+            nodeLocationOverrides={this.state.locationOverrides}
           />
         </div>
       </>

--- a/src/utilities/layout-engine/horizontal-tree.js
+++ b/src/utilities/layout-engine/horizontal-tree.js
@@ -36,6 +36,8 @@ class HorizontalTree extends SnapToGrid {
     const g = new dagre.graphlib.Graph();
     const height = nodeHeight ? nodeHeight * spacing : size;
     const width = nodeWidth ? nodeWidth * spacing : size;
+    const renderOrphanEnabled =
+      (graphConfig && graphConfig.renderOrphanEnabled) || false;
 
     g.setGraph(
       Object.assign(
@@ -62,6 +64,7 @@ class HorizontalTree extends SnapToGrid {
 
       // prevent disconnected nodes from being part of the graph
       if (
+        !renderOrphanEnabled &&
         nodesMapNode.incomingEdges.length === 0 &&
         nodesMapNode.outgoingEdges.length === 0
       ) {


### PR DESCRIPTION
Issue: when using `layoutEngine`, updating nodes location (dragging nodes) will call `layoutEngineAdjustNodes` before returning `onUpdateNode`, which will mutate updating node location so the `x` and `y` for the updating node always returning the same values