### PR TITLE
adjacent node hover bug

### DIFF
--- a/src/components/node.js
+++ b/src/components/node.js
@@ -126,11 +126,25 @@ function Node({
 
   const handleMouseOut = useCallback(
     (event: any) => {
+      const mouseEvent: MouseEvent = event.nativeEvent;
+      const exitedElement: Element = mouseEvent.target;
+      const enteredElement: Element = mouseEvent.relatedTarget;
+      const exitedGNode = GraphUtils.findParent(
+        exitedElement,
+        'g.node',
+        'svg.graph'
+      );
+      const enteredGNode = GraphUtils.findParent(
+        enteredElement,
+        'g.node',
+        'svg.graph'
+      );
+      const isHovered: boolean = !!enteredGNode; // if we find a G element, user is hovered over a node
+
       if (
         (event && !event.relatedTarget) ||
-        (event &&
-          !event.relatedTarget?.matches('.edge-overlay-path') &&
-          !GraphUtils.findParent(event.relatedTarget, 'g.node', 'svg.graph'))
+        /* if user is not currently hovered, or was just hovering an adjacent node */
+        (event && (!isHovered || exitedGNode !== enteredGNode))
       ) {
         setHovered(false);
         onNodeMouseLeave(event, data);


### PR DESCRIPTION
The hovered node selection does not disappear when the mouse immediately hovers over an adjacent node (without touching the background).  See the screenshot where the top 3 nodes remain selected simultaneously.  If this behavior is intentional and not a bug, then my mistake!  :)

![hovered](https://user-images.githubusercontent.com/9879823/134781260-94e551bc-9501-453b-9488-716f021244a1.png)


