### PR TITLE
Add flag to allow edges to be copied without any nodes selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Version 8.0.0 introduces multi-select nodes and edges using Ctrl-Shift-Mouse eve
 
 To disable multi-select you can set `allowMultiselect` to `false`, which disables the Ctrl-Shift-mouse event, but we will still use the `onSelect` function. Both `onSelectNode` and `onSelectEdge` are deprecated.
 
-Breaking changes: 
+Breaking changes:
 
 - `onPasteSelected` now accepts a `SelectionT` object for the first parameter
-- `onPasteSelected` now accepts an `IPoint` instead 
+- `onPasteSelected` now accepts an `IPoint` instead
 of a `XYCoords` array for the second parameter.
 - `onDeleteSelected` is added which takes a `SelectionT` parameter.
 - `onSelect` is added, which accepts `SelectionT` and `Event` parameters.
@@ -226,7 +226,8 @@ All props are detailed below.
 | `nodeKey`                  | `string`                   | `true`       | Key for D3 to update nodes(typ. UUID).                                                                                                                                                      |
 | `nodes`                    | `Array<INode>`             | `true`       | Array of graph nodes.                                                                                                                                                                       |
 | `edges`                    | `Array<IEdge>`             | `true`       | Array of graph edges.                                                                                                                                                                       |
-| `allowMultiselect`         | `boolean`    | `false`      | (default true) Use Ctrl-Shift-LeftMouse to draw a multiple selection box. |
+| `allowCopyEdges`           | `boolean`                  | `false`      | (default false) Allow `onCopySelected` to be called when an edge is selected without any nodes. |
+| `allowMultiselect`         | `boolean`                  | `false`      | (default true) Use Ctrl-Shift-LeftMouse to draw a multiple selection box. |
 | `selected`                 | `object`                   | `true`       | The currently selected graph entity. |
 | `nodeTypes`                | `object`                   | `true`       | Config object of available node types.                                                                                                                                                      |
 | `nodeSubtypes`             | `object`                   | `true`       | Config object of available node subtypes.                                                                                                                                                   |
@@ -237,7 +238,7 @@ All props are detailed below.
 | `onUpdateNode`             | `func`                     | `true`       | Called when a node is moved.|
 | `onCreateEdge`             | `func`                     | `true`       | Called when an edge is created.|
 | `onSwapEdge`               | `func`                     | `true`       | Called when an edge `'target'` is swapped.|
-| `onBackgroundClick`        | `func`                     | `false`      | Called when the background is clicked.  |                                                                                                                         
+| `onBackgroundClick`        | `func`                     | `false`      | Called when the background is clicked.  |
 | `onArrowClicked`        | `func`                     | `false`      | Called when the arrow head is clicked. |
 | `onUndo`                | `func` | `false` | A function called when Ctrl-Z is activated. React-digraph does not keep track of actions, this must be implemented in the client website. |
 | `onCopySelected` | `func` | `false` | A function called when Ctrl-C is activated. React-digraph does not keep track of copied nodes or edges, the this must be implemented in the client website. |

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "main": "dist/main.min.js",
   "types": "./typings/index.d.ts",
   "peerDependencies": {
+    "d3": "^5.16.0",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0",
-    "d3": "^5.16.0"
+    "react-dom": "^16.12.0"
   },
   "dependencies": {
     "dagre": "^0.8.2",
@@ -92,8 +92,8 @@
     "jest": "^26.5.0",
     "jsdom": "^11.12.0",
     "lint-staged": "^8.2.0",
-    "live-server": "^1.2.0",
-    "node-sass": "^4.9.2",
+    "live-server": "^1.2.2",
+    "node-sass": "^6.0.1",
     "npm-run-all": "^4.1.3",
     "opn-cli": "3.1.0",
     "prettier": "^1.19.1",

--- a/src/components/graph-view-props.js
+++ b/src/components/graph-view-props.js
@@ -37,6 +37,7 @@ export type SelectionT = {
 };
 
 export type IGraphViewProps = {
+  allowCopyEdges?: boolean,
   allowMultiselect?: boolean,
   backgroundFillId?: string,
   disableBackspace?: boolean,

--- a/src/components/graph-view.js
+++ b/src/components/graph-view.js
@@ -80,6 +80,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     canSwapEdge: () => true,
     canDeleteSelected: () => true,
     allowMultiselect: true,
+    allowCopyEdges: false,
     edgeArrowSize: 8,
     gridSpacing: 36,
     layoutEngineType: 'None',
@@ -580,6 +581,7 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
     const {
       selected,
       disableBackspace,
+      allowCopyEdges,
       onUndo,
       onCopySelected,
       onPasteSelected,
@@ -610,7 +612,10 @@ class GraphView extends React.Component<IGraphViewProps, IGraphViewState> {
 
         break;
       case 'c':
-        if (this.isControlKeyPressed(d) && selected?.nodes?.size) {
+        if (
+          this.isControlKeyPressed(d) &&
+          (selected?.nodes?.size || (allowCopyEdges && selected?.edges?.size))
+        ) {
           onCopySelected && onCopySelected();
         }
 


### PR DESCRIPTION
Adding a new `allowCopyEdges` flag that bypasses the requirement that a node is selected in order for a copy event to be passed to `onCopySelected` if at least one edge is selected.