### PR TITLE
find non-empty edge element for panToNode method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-digraph",
   "description": "directed graph react component",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "keywords": [
     "uber-library",
     "babel",

--- a/src/components/graph-view-v2.js
+++ b/src/components/graph-view-v2.js
@@ -1943,9 +1943,13 @@ class GraphViewV2 extends React.Component<IGraphViewProps, IGraphViewState> {
       return;
     }
 
-    const edge = this.entities.querySelector(
-      `[id='edge-${source}-${target}-container']`
-    );
+    const edge =
+      [
+        ...this.entities?.querySelectorAll(
+          `[id='edge-${source}-${target}-container']`
+        ),
+      ]?.find(element => !!element.innerHTML) ||
+      this.entities.querySelector(`[id='edge-${source}-${target}-container']`);
 
     this.panToEntity(edge, zoom);
   }


### PR DESCRIPTION
There is a bug where the graph cannot locate the correct edge position when panTo. This is because there are two element with same id but the first one is empty. For example
<img width="1419" alt="Screenshot 2023-09-05 at 12 13 08" src="https://github.com/uber/react-digraph/assets/93685999/d05e56f5-42e3-41fa-80a6-3c61b8a65f9e">
To fix this, we do querySelectorAll and try to find the correct edge.

